### PR TITLE
CUI 2023 full papers information

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -183,3 +183,18 @@
   hindex: 33
   sub: HCI
   note: Mandatory abstract deadline on April 12, 2023.
+  
+- title: CUI
+  year: 2023
+  id: cui23
+  full_name: Conversational User Interfaces
+  link: https://cui.acm.org/2023/
+  deadline: '2023-02-22 23:59:59'
+  abstract_deadline: '2023-02-15 23:59:59'
+  timezone: UTC-12
+  place: Eindhoven, Netherlands
+  date: July, 19-21, 2023
+  start: 2023-07-19
+  end: 2023-07-21
+  sub: HCI
+  note: Mandatory abstract deadline on February 15, 2023.


### PR DESCRIPTION
ACM CUI full papers deadline is soon.

https://cui.acm.org/2023/