### PR TITLE
Added ISMAR 23 Journal Papers

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -236,3 +236,4 @@
   start: 2023-10-16
   end: 2023-10-20
   sub: VR
+  note: Mandatory abstract deadline on March 19, 2023.

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -224,3 +224,15 @@
   start: 2023-10-10
   end: 2023-10-13
   sub: HCI
+  
+- title: ISMAR (Journal Papers)
+  year: 2023
+  id: ismar23j
+  link: https://ismar23.org/call-for-journal-papers/
+  deadline: '2023-03-23 23:59:59'
+  timezone: UTC-12
+  place: Sydney, Australia
+  date: October, 16-20, 2023
+  start: 2023-10-16
+  end: 2023-10-20
+  sub: VR


### PR DESCRIPTION
Added ISMAR 23 Journal Papers!
(https://ismar23.org/call-for-journal-papers/)

One suggestion: how about changing the subject 'Virtual Reality (VR)' to 'Augmented, Virtual and Mixed Reality (XR)'? (abbreviation from [VRST 22 CFP](https://vrst.acm.org/vrst2022/submissions/))
Many conferences including IEEE VR, ISMAR, and VRST covers not only VR, but also AR, MR too!