### PR TITLE
Added abstract deadlines

### DIFF
--- a/_includes/calendar.js
+++ b/_includes/calendar.js
@@ -41,7 +41,7 @@
               content +=
                 '<div class="event-tooltip-content">' +
                 '<div class="event-name ' + headline_color + '">' +
-                '<b>' + e.events[i].name + '</b>' + 
+                '<b>' + e.events[i].name + '</b>' +
                 '</div>' +
                 '<div class="event-location">' +
                 location_html +
@@ -98,6 +98,21 @@ function load_conference_list() {
       startDate: Date.parse("{{conf.deadline}}"),
       endDate: Date.parse("{{conf.deadline}}"),
     });
+
+    {% if conf.abstract_deadline != "" %}
+    conf_list_all.push({
+      id: "{{conf.id}}-abstract-deadline",
+      abbreviation: "{{conf.id}}",
+      name: "{{conf.title}} {{conf.year}} - Abstract Deadline",
+      color: "red",
+      location: "{{conf.place}}",
+      date: "{{conf.date}}",
+      hindex: "{{conf.hindex}}",
+      subject: "{{conf.sub}}",
+      startDate: Date.parse("{{conf.abstract_deadline}}"),
+      endDate: Date.parse("{{conf.abstract_deadline}}"),
+    });
+    {% endif %}
 
     // add Conferences in chosen color
     {% if conf.start != "" %}

--- a/_pages/conference.html
+++ b/_pages/conference.html
@@ -59,19 +59,36 @@ permalink: /conference/
           <a id="conf-pwclink" target="_blank" nohref></a>
         </div>
       </div>
-      <div id="conf-deadline-info" class="row">
+      <div id="conf-deadline-download" class="row">
         <div class="meta deadline col-12 col-md-6">
           Download Conference deadline:
         </div>
         <div id="conference-deadline" class="calendar meta col-sm-12 col-md-6">
         </div>
+      </div>
+      <div id="abstract-deadline-info" class="row">
+        <div class="meta deadline col-12 col-md-6">
+          Abstract deadline in timezone from conference website:
+        </div>
+        <div class="meta col-sm-12 col-md-6">
+          <span class="abstract-deadline-time"></span>
+        </div>
+        <div class="local-timezone-hide meta col-sm-12 col-md-6">
+          Abstract deadline in your local <span class="local-timezone">America/New_York</span> timezone:
+        </div>
+        <div class="local-timezone-hide meta col-sm-12 col-md-6">
+          <span class="abstract-deadline-local-time"></span>
+        </div>
+
+      </div>
+      <div id="conf-deadline-info" class="row">
         <div class="meta deadline col-12 col-md-6">
           Deadline in timezone from conference website:
         </div>
         <div class="meta col-sm-12 col-md-6">
           <span class="deadline-time"></span>
         </div>
-        <div class="meta col-sm-12 col-md-6">
+        <div class="local-timezone-hide meta col-sm-12 col-md-6">
           Deadline in your local <span class="local-timezone">America/New_York</span> timezone:
         </div>
         <div class="local-timezone-hide meta col-sm-12 col-md-6">
@@ -151,7 +168,7 @@ permalink: /conference/
         var timezone = {% if conf.timezone %} "{{conf.timezone}}" {% else %} "America/New_York" {% endif %};
       var confDeadline = moment.tz("{{conf.deadline}}", timezone);
 
-      // add calendar 
+      // add calendar
       var conferenceDeadlineCalendar = createCalendarFromObject({
         id: '{{conf.id}}',
         title: '{{conf.title}} {{conf.year}} deadline',
@@ -174,6 +191,29 @@ permalink: /conference/
       catch (err) {
         console.log("Error converting to local timezone.");
       }
+
+      // abstract deadline
+      {% if conf.abstract_deadline %}
+      console.log("Abstract deadline: {{conf.abstract_deadline}}");
+      try {
+        var abstractDeadline = moment.tz("{{conf.abstract_deadline}}", timezone);
+        $('.abstract-deadline-time').html(abstractDeadline.toString());
+      } catch (err) {
+        console.log("Error parsing abstract deadline.");
+        $('#abstract-deadline-info').hide();
+      }
+      try {
+        var localAbstractDeadline = moment.tz(abstractDeadline, local_timezone);
+        $('.abstract-deadline-local-time').html(localAbstractDeadline.toString());
+      }
+      catch (err) {
+        console.log("Error converting to local timezone.");
+      }
+      {% else %}
+      console.log("No abstract deadline.");
+      $('#abstract-deadline-info').hide();
+      {% endif %}
+
       {% endif %}
     }
         {% endfor %}

--- a/index.html
+++ b/index.html
@@ -130,8 +130,15 @@
 
             </div>
             <div class="col-12 col-sm-6">
+              {% if conf.abstract_deadline %}
               <div class="deadline">
-                <div>Deadline:
+                <div><b>Abstract deadline:</b>
+                  <span class="abstract-deadline-time"></span>
+                </div>
+              </div>
+              {% endif %}
+              <div class="deadline">
+                <div><b>Deadline:</b>
                   <span class="deadline-time"></span>
                 </div>
               </div>
@@ -197,6 +204,10 @@
       // adjust date according to deadline timezone
       var timezone = {% if conf.timezone %}"{{conf.timezone}}" {% else %} "America/New_York" {% endif %};
     var confDate = moment.tz("{{conf.deadline}}", timezone);
+    var abstractDeadline = null;
+    {% if conf.abstract_deadline %}
+    abstractDeadline = moment.tz("{{conf.abstract_deadline}}", timezone);
+    {% endif %}
 
     // render countdown timer
     $('#{{conf.id}} .timer').countdown(confDate.toDate(), function (event) {
@@ -215,6 +226,17 @@
     }
     catch (err) {
       console.log("Error converting to local timezone.");
+    }
+
+    // convert abstract deadline to local timezone
+    if (abstractDeadline) {
+      try {
+        var localAbstractDeadline = moment.tz(abstractDeadline, local_timezone);
+        $('#{{conf.id}} .abstract-deadline-time').html(localAbstractDeadline.toString());
+      }
+      catch (err) {
+        console.log("Error converting to local timezone.");
+      }
     }
 
     // add calendar button


### PR DESCRIPTION
Added abstract deadlines to show on homepage, calendar page and individual conference page. This will only show if the conference has a `abstract_deadline` field. With so many conferences having a set abstract deadline I thought it might be worth moving it from the notes field to its own field.

## Homepage
<img width="700" alt="Screenshot 2024-08-05 at 13 37 11" src="https://github.com/user-attachments/assets/e6625df3-4361-4385-ae23-9ef1e6d0085b">

## Conference Page
<img width="700" alt="Screenshot 2024-08-05 at 13 36 48" src="https://github.com/user-attachments/assets/332603c8-f92e-4be6-958d-bfd39313feae">

## Calendar Page
<img width="517" alt="Screenshot 2024-08-05 at 13 39 58" src="https://github.com/user-attachments/assets/6820450b-3d0a-4145-83dc-00d62e4cbbb7">
