### PR TITLE
Fix VRST'25 location

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1310,7 +1310,7 @@
   deadline: '2025-06-14 23:59:59'
   abstract_deadline: '2025-06-07 23:59:59'
   timezone: UTC-12
-  place: Trier, Germany
+  place: Montreal, Canada
   date: November, 12-14, 2025
   start: 2025-11-12
   end: 2025-11-14


### PR DESCRIPTION
This year's VRST will be hosted in Montreal (Canada), see https://vrst.acm.org/vrst2025/
Looks like a copy-paste error from the previous VRST.
