### PR TITLE
Use tabular lining numerals in countdown

### DIFF
--- a/static/css/deadlines.css
+++ b/static/css/deadlines.css
@@ -141,6 +141,7 @@ footer {
 .timer-small {
   font-size: 20px;
   font-weight: 400;
+  font-variant-numeric: tabular-nums;
 }
 
 #confs {


### PR DESCRIPTION
Previously, the (default) proportional numbers made line lengths vary depending on the numbers shown. Now, the countdown always occupies the same horizontal space, cf. https://drafts.csswg.org/css-fonts/#valdef-font-variant-numeric-tabular-nums