### PR TITLE
Update conference data and separate incomplete entries into TBA page

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,3 @@
-
 - title: ACII
   year: 2023
   id: acii2023
@@ -34,6 +33,51 @@
   start: 2025-10-08
   end: 2025-10-11
   sub: HCI
+
+- title: ACM Multimedia
+  year: 2026
+  id: acmmm26
+  full_name: ACM International Conference on Multimedia
+  link: https://2026.acmmm.org/
+  deadline: '2026-04-01 23:59:59'
+  abstract_deadline: '2026-03-25 23:59:59'
+  timezone: UTC-12
+  place: Rio de Janeiro, Brazil
+  date: November, 10-14, 2026
+  start: 2026-11-10
+  end: 2026-11-14
+  sub: ['HCI', 'MM']
+  note: Main-track abstract registration deadline March 25, 2026 and full paper deadline April 1, 2026 (official 2026 site).
+
+- title: IEEE AIA Workshop
+  year: 2025
+  id: aia25
+  full_name: IEEE Workshop on Artificial Intelligence for Art Creation (AIART)
+  link: https://aiart-2025.github.io/
+  deadline: '2025-04-01 23:59:59'
+  abstract_deadline: ""
+  timezone: UTC-12
+  place: Nantes, France
+  date: July, 4, 2025
+  start: 2025-07-04
+  end: 2025-07-04
+  sub: ['AI', 'DES', 'VIS']
+  note: AIART 2025 (jointly with ICME 2025); workshop paper submissions due April 1, 2025.
+
+- title: ArtsIT
+  year: 2026
+  id: artsit26
+  full_name: International Conference on ArtsIT, Interactivity and Game Creation
+  link: https://artsit.eai-conferences.org/2026/
+  deadline: '2026-06-01 23:59:59'
+  abstract_deadline: ""
+  timezone: UTC-12
+  place: Bratislava, Slovakia
+  date: December, 2-4, 2026
+  start: 2026-12-02
+  end: 2026-12-04
+  sub: ['HCI', 'DES', 'GAMES']
+  note: Official ArtsIT 2026 call lists full-paper submission deadline as June 1, 2026.
 
 - title: ASSETS
   year: 2023
@@ -159,10 +203,10 @@
   end: 2026-09-23
   sub: HCI
 
-- title: CC
+- title: "ACM Creativity & Cognition (C&C)"
   year: 2025
   id: cc25
-  full_name: Creativity & Cognition
+  full_name: "ACM Creativity & Cognition Conference"
   link: https://cc.acm.org/2025/
   deadline: '2025-02-06 23:59:59'
   abstract_deadline: '2025-01-30 23:59:59'
@@ -173,19 +217,20 @@
   end: 2025-06-25
   sub: HCI
 
-- title: CC
+- title: "ACM Creativity & Cognition (C&C)"
   year: 2026
   id: cc26
-  full_name: Creativity & Cognition
+  full_name: "ACM Creativity & Cognition Conference"
   link: https://cc.acm.org/2026/
   deadline: '2026-02-05 23:59:59'
   abstract_deadline: '2026-01-29 23:59:59'
   timezone: UTC-12
-  place: Online
+  place: London, UK
   date: July, 13-16, 2026
   start: 2026-07-13
   end: 2026-07-16
   sub: HCI
+  note: Official 2026 site states the conference is in-person in London, UK (Central Saint Martins, University of the Arts London).
 
 - title: CHI
   year: 2023
@@ -351,10 +396,12 @@
   year: 2026
   id: cscw26
   link: https://cscw.acm.org/2026/papers.html
-  deadline: '2025-05-13 23:59:59'
+  deadline: '2025-05-14 04:00:00'
   timezone: UTC-12
-  place: TBA
-  date: TBA
+  place: Salt Lake City, Utah, USA
+  date: October, 10-14, 2026
+  start: 2026-10-10
+  end: 2026-10-14
   sub: CSCW
 
 - title: CUI
@@ -635,6 +682,21 @@
   place: Athens, Greece
   date: TBD
   sub: HCI
+
+- title: IEEE CoG
+  year: 2025
+  id: cog25
+  full_name: IEEE Conference on Games
+  link: https://cog2025.inesc-id.pt/call-for-papers/
+  deadline: '2025-03-15 23:59:59'
+  abstract_deadline: ""
+  timezone: UTC-12
+  place: Lisbon, Portugal
+  date: August, 26-29, 2025
+  start: 2025-08-26
+  end: 2025-08-29
+  sub: ['HCI', 'AI', 'DES']
+  note: User-requested IEEE GEM mapped to IEEE CoG; full paper deadline March 15, 2025.
 
 - title: Graphics Interface (December round)
   year: 2025
@@ -961,6 +1023,36 @@
   end: 2025-10-15
   sub: HCI
 
+- title: ACM IMX
+  year: 2026
+  id: imx26
+  full_name: ACM International Conference on Interactive Media Experiences
+  link: https://imx.acm.org/2026/authors/important-dates/
+  deadline: '2026-01-22 23:59:59'
+  abstract_deadline: ""
+  timezone: UTC-12
+  place: Athlone, Ireland
+  date: June, 9-11, 2026
+  start: 2026-06-09
+  end: 2026-06-11
+  sub: ['HCI', 'DES']
+  note: Paper-track submission deadline extended from Jan 15 to Jan 22, 2026; all deadlines are AoE.
+
+- title: ISEA
+  year: 2026
+  id: isea26
+  full_name: International Symposium on Electronic Art
+  link: https://isea-international.org/
+  deadline: '2025-12-20 23:59:59'
+  abstract_deadline: ""
+  timezone: UTC-12
+  place: Dubai, UAE
+  date: April, 10-19, 2026
+  start: 2026-04-10
+  end: 2026-04-19
+  sub: ['DES', 'VIS', 'HCI']
+  note: ISEA2026 announced for Dubai (Apr 10-19, 2026); current official call lists Dec 20, 2025 as key submission deadline.
+
 - title: ISMAR (Journal Papers)
   year: 2023
   id: ismar23j
@@ -1218,6 +1310,21 @@
   end: 2026-09-03
   sub: HCI
 
+- title: NIME
+  year: 2026
+  id: nime26
+  full_name: International Conference on New Interfaces for Musical Expression
+  link: https://nime2026.org/
+  deadline: '2026-02-12 23:59:59'
+  abstract_deadline: '2026-02-05 23:59:59'
+  timezone: UTC-12
+  place: London, UK
+  date: June, 24-26, 2026
+  start: 2026-06-24
+  end: 2026-06-26
+  sub: ['HCI', 'MUSIC']
+  note: NIME 2026 abstract deadline Feb 5, 2026 and full submission deadline Feb 12, 2026 (AoE).
+
 - title: IEEE PacificVis
   year: 2024
   id: pacificvis24
@@ -1262,6 +1369,66 @@
   end: 2026-04-23
   sub: VIS
   note: Conference paper track
+
+- title: ACM PDC
+  year: 2026
+  id: pdc26
+  full_name: ACM Participatory Design Conference
+  link: https://www.pdc2026.polimi.it/calls/
+  deadline: '2025-06-16 23:59:59'
+  abstract_deadline: ""
+  timezone: UTC-12
+  place: Milan, Italy
+  date: June, 15-19, 2026
+  start: 2026-06-15
+  end: 2026-06-19
+  sub: ['HCI', 'DES', 'CSCW']
+  note: Latest official PDC 2026 call information indicates full-paper deadline June 16, 2025.
+
+- title: POM
+  year: 2025
+  id: pom25
+  full_name: Politics of the Machines
+  link: https://pom-conference.org/pom-perth-2025/
+  deadline: '2025-03-29 23:59:59'
+  abstract_deadline: ""
+  timezone: UTC-12
+  place: Perth, Australia
+  date: July, 16-18, 2025
+  start: 2025-07-16
+  end: 2025-07-18
+  sub: ['DES', 'HCI']
+  note: POM Perth 2025 call for abstracts extended deadline is March 29, 2025.
+
+- title: ACM SIGGRAPH
+  year: 2026
+  id: siggraph26
+  full_name: ACM SIGGRAPH Conference and Exhibition on Computer Graphics and Interactive Techniques
+  link: https://s2026.siggraph.org/
+  deadline: '2026-01-22 10:00:00'
+  abstract_deadline: '2026-01-15 10:00:00'
+  timezone: UTC-12
+  place: Los Angeles, CA, USA
+  date: July, 19-23, 2026
+  start: 2026-07-19
+  end: 2026-07-23
+  sub: ['HCI', 'CG']
+  note: Technical Papers deadlines are announced as January 15/22, 2026 at 22:00 UTC (stored here in UTC-12 equivalent).
+
+- title: ACM SIGGRAPH Asia
+  year: 2025
+  id: siggraphasia25
+  full_name: ACM SIGGRAPH Asia Conference and Exhibition on Computer Graphics and Interactive Techniques in Asia
+  link: https://asia.siggraph.org/2025/submissions/technical-papers/
+  deadline: '2025-05-23 23:59:59'
+  abstract_deadline: '2025-05-16 23:59:59'
+  timezone: UTC-12
+  place: Hong Kong
+  date: December, 15-18, 2025
+  start: 2025-12-15
+  end: 2025-12-18
+  sub: ['HCI', 'CG']
+  note: Technical Papers form deadline May 16, 2025; full PDF/assets deadline May 23, 2025.
 
 - title: SUI
   year: 2023
@@ -1454,6 +1621,21 @@
   end: 2025-11-07
   sub: VIS
 
+- title: VISAP
+  year: 2025
+  id: visap25
+  full_name: IEEE VIS Arts Program
+  link: https://visap.net/2025/submission.html
+  deadline: '2025-06-20 23:59:59'
+  abstract_deadline: ""
+  timezone: UTC-12
+  place: Vienna, Austria
+  date: November, 6-15, 2025
+  start: 2025-11-06
+  end: 2025-11-15
+  sub: ['VIS', 'DES', 'HCI']
+  note: Submission deadline extended to June 20, 2025 (AoE); VISAP exhibition Nov 6-15, 2025.
+
 - title: VL/HCC
   year: 2023
   id: vlhcc23
@@ -1612,3 +1794,19 @@
   start: 2025-07-08
   end: 2025-07-11
   sub: HAP
+
+- title: xCoAx
+  year: 2026
+  id: xcoax26
+  full_name: Conference on Computation, Communication, Aesthetics and X
+  link: https://xcoax.org/
+  deadline: '2026-02-15 23:59:59'
+  abstract_deadline: ""
+  timezone: UTC-12
+  place: Torino, Italy
+  date: July, 8-10, 2026
+  start: 2026-07-08
+  end: 2026-07-10
+  sub: ['DES', 'VIS', 'HCI']
+  note: xCoAx 2026 submissions deadline was extended from Feb 1 to Feb 15, 2026 (AoE).
+

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1023,6 +1023,21 @@
   end: 2025-10-15
   sub: HCI
 
+- title: ACM IDC
+  year: 2026
+  id: idc26
+  full_name: ACM Interaction Design and Children
+  link: https://idc2026.sites.uu.nl/calls/full-and-short-papers/
+  deadline: '2026-01-27 23:59:59'
+  abstract_deadline: '2026-01-20 23:59:59'
+  timezone: UTC-12
+  place: Brighton, UK
+  date: June, 22-25, 2026
+  start: 2026-06-22
+  end: 2026-06-25
+  sub: ['HCI', 'DES']
+  note: Full/Short Papers deadlines are Jan 20, 2026 (abstract) and Jan 27, 2026 (submission), AoE.
+
 - title: ACM IMX
   year: 2026
   id: imx26

--- a/_data/types.yml
+++ b/_data/types.yml
@@ -1,28 +1,38 @@
----
 - name: Human-Computer Interaction
   sub: HCI
-  color: '#ffd300'
+
 - name: Design
   sub: DES
-  color: '#2EA87D'
+
+- name: Games
+  sub: GAMES
+
+- name: Multimodel
+  sub: MM
+
+- name: Computer Graphics
+  sub: CG
+
+- name: Music
+  sub: MUSIC
+
 - name: CSCW
   sub: CSCW
-  color: '#0aefff'
+
 - name: AI+HCI
   sub: AI
-  color: '#147df5'
+
 - name: Human-Robot Interaction
   sub: HRI
-  color: '#0aff99'
+
 - name: Augmented, Virtual and Mixed Reality
   sub: XR
-  color: '#580aff'
+
 - name: Haptics
   sub: HAP
-  color: '#be0aff'
+
 - name: Visualization
   sub: VIS
-  color: '#a432a8'
+
 - name: Security and Privacy
   sub: SP
-  color: '#a43208'

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,25 +6,25 @@
 <meta name="description" content="{{ site.description }}">
 <meta name="author" content="{{ site.author }}">
 <meta name="keywords" content="HCI, deadlines, conference">
-<link rel="stylesheet" type="text/css" href="{{ " /static/css/js-year-calendar.min.css" | prepend:site.baseurl
+<link rel="stylesheet" type="text/css" href="{{ "/static/css/js-year-calendar.min.css" | prepend:site.baseurl
     }}?t={{site.time | date: '%s' }}" media="screen,projection">
 
-<link rel="stylesheet" type="text/css" href="{{ " /static/css/bootstrap.min.css" | prepend:site.baseurl }}">
-<link rel="stylesheet" type="text/css" href="{{ " /static/css/deadlines.css" | prepend:site.baseurl }}?t={{site.time |
+<link rel="stylesheet" type="text/css" href="{{ "/static/css/bootstrap.min.css" | prepend:site.baseurl }}">
+<link rel="stylesheet" type="text/css" href="{{ "/static/css/deadlines.css" | prepend:site.baseurl }}?t={{site.time |
     date: '%s' }}" media="screen,projection">
-<link rel="stylesheet" type="text/css" href="{{ " /static/css/calendar.css" | prepend:site.baseurl }}?t={{site.time |
+<link rel="stylesheet" type="text/css" href="{{ "/static/css/calendar.css" | prepend:site.baseurl }}?t={{site.time |
     date: '%s' }}" media="screen,projection">
 
-<link rel="shortcut icon" href="{{ " /static/img/favicon.png" | prepend:site.baseurl }}">
+<link rel="shortcut icon" href="{{ "/static/img/favicon.png" | prepend:site.baseurl }}">
 
-<script type="text/javascript" src="{{ " /static/js/js-year-calendar.js" | prepend:site.baseurl }}"></script>
-<script type="text/javascript" src="{{ " /static/js/jquery.min.js" | prepend:site.baseurl }}"></script>
-<script type="text/javascript" src="{{ " /static/js/popper.min.js" | prepend:site.baseurl }}"></script>
-<script type="text/javascript" src="{{ " /static/js/bootstrap.min.js" | prepend:site.baseurl }}"></script>
-<script type="text/javascript" src="{{ " /static/js/jquery.countdown.min.js" | prepend:site.baseurl }}"></script>
-<script type="text/javascript" src="{{ " /static/js/moment.min.js" | prepend:site.baseurl }}"></script>
-<script type="text/javascript" src="{{ " /static/js/moment-timezone-with-data.min.js" | prepend:site.baseurl
+<script type="text/javascript" src="{{ "/static/js/js-year-calendar.js" | prepend:site.baseurl }}"></script>
+<script type="text/javascript" src="{{ "/static/js/jquery.min.js" | prepend:site.baseurl }}"></script>
+<script type="text/javascript" src="{{ "/static/js/popper.min.js" | prepend:site.baseurl }}"></script>
+<script type="text/javascript" src="{{ "/static/js/bootstrap.min.js" | prepend:site.baseurl }}"></script>
+<script type="text/javascript" src="{{ "/static/js/jquery.countdown.min.js" | prepend:site.baseurl }}"></script>
+<script type="text/javascript" src="{{ "/static/js/moment.min.js" | prepend:site.baseurl }}"></script>
+<script type="text/javascript" src="{{ "/static/js/moment-timezone-with-data.min.js" | prepend:site.baseurl
     }}"></script>
-<script type="text/javascript" src="{{ " /static/js/store.min.js" | prepend:site.baseurl }}"></script>
-<script type="text/javascript" src="{{ " /static/js/ouical.min.js" | prepend:site.baseurl }}"></script>
-<script type="text/javascript" src="{{ " /static/js/bootstrap-multiselect.min.js" |prepend:site.baseurl }}"></script>
+<script type="text/javascript" src="{{ "/static/js/store.min.js" | prepend:site.baseurl }}"></script>
+<script type="text/javascript" src="{{ "/static/js/ouical.min.js" | prepend:site.baseurl }}"></script>
+<script type="text/javascript" src="{{ "/static/js/bootstrap-multiselect.min.js" |prepend:site.baseurl }}"></script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,6 +21,9 @@
         <li>
           <a href="{{site.baseurl}}/calendar" class="nav-link" style="border-bottom: none;">Calendar</a>
         </li>
+        <li>
+          <a href="{{site.baseurl}}/tba" class="nav-link" style="border-bottom: none;">TBA Conferences</a>
+        </li>
       </ul>
       <div class="twitter-github-icons">
         <a href="https://twitter.com/share" class="twitter-share-button"

--- a/_pages/tba.html
+++ b/_pages/tba.html
@@ -1,0 +1,120 @@
+---
+permalink: /tba/
+---
+
+<html>
+  <head>
+    {% include head.html %}
+  </head>
+
+  <body>
+    {% include header.html %}
+    <div class="container">
+      <div class="page-header">
+        <div class="row">
+          <div class="col-12 col-sm-12">
+            <h1>TBA Conferences</h1>
+          </div>
+          <div class="meta col-12">
+            Conferences with incomplete metadata (TBA/TBD/empty fields). These are hidden from the main countdown page until details are complete.
+          </div>
+        </div>
+      </div>
+
+      <div id="tba_confs">
+        {% assign tba_count = 0 %}
+        {% assign sorted_confs = site.data.conferences | sort: "year" | reverse %}
+        {% for conf in sorted_confs %}
+        {% assign deadline_value = conf.deadline | append: "" | upcase %}
+        {% assign date_value = conf.date | append: "" | upcase %}
+        {% assign place_value = conf.place | append: "" | upcase %}
+        {% assign start_value = conf.start | append: "" %}
+        {% assign end_value = conf.end | append: "" %}
+        {% assign has_tba = false %}
+        {% if deadline_value contains "TBA" or deadline_value contains "TBD" or date_value contains "TBA" or date_value contains "TBD" or place_value contains "TBA" or place_value contains "TBD" or start_value == "" or end_value == "" %}
+        {% assign has_tba = true %}
+        {% endif %}
+
+        {% if has_tba %}
+        {% assign tba_count = tba_count | plus: 1 %}
+        <div id="{{conf.id}}" class="ConfItem {% for sub in conf.sub %} {{sub}}-conf {% endfor %}">
+          <div class="row conf-row">
+            <div class="col-12 col-sm-7">
+              <span class="conf-title">
+                <a
+                  title="{% if conf.full_name %}{{conf.full_name}}{% else %}Deadline{% endif %} Details"
+                  href="{{site.baseurl}}/conference?id={{ conf.id }}"
+                  >{{conf.title}} {{conf.year}}</a
+                >
+              </span>
+              <span class="conf-title-icon">
+                <a
+                  title="Conference Website"
+                  href="{{conf.link}}"
+                  target="_blank"
+                  ><img
+                    src="{{site.baseurl}}/static/img/203-earth.svg"
+                    class="badge-link"
+                    alt="Link to Conference Website"
+                /></a>
+              </span>
+            </div>
+            <div class="col-12 col-sm-5 deadline">
+              <b>Deadline:</b>
+              {% if conf.deadline %}{{conf.deadline}}{% else %}TBA{% endif %}
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-12 col-sm-6">
+              <div class="meta">
+                <span class="conf-date">{% if conf.date and conf.date != "" %}{{conf.date}}{% else %}TBA{% endif %}.</span>
+                <span class="conf-place">
+                  {% if conf.place and conf.place != "" and conf.place != "Online" %}
+                  <a href="http://maps.google.com/?q={{conf.place}}">{{conf.place}}</a>.
+                  {% elsif conf.place == "Online" %}
+                  <a href="#">{{conf.place}}</a>.
+                  {% else %}
+                  <a href="#">TBA</a>.
+                  {% endif %}
+                </span>
+              </div>
+              {% if conf.note %}
+              <div class="note"><b>Note: </b>{{conf.note}}</div>
+              {% endif %}
+            </div>
+            <div class="col-12 col-sm-6">
+              {% if conf.abstract_deadline %}
+              <div class="deadline"><b>Abstract deadline:</b> {{conf.abstract_deadline}}</div>
+              {% endif %}
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-12">
+              {% for sub in conf.sub %}
+              {% assign sub_name = sub %}
+              {% for type in site.data.types %}
+              {% if type.sub == sub %}
+              {% assign sub_name = type.name %}
+              {% endif %}
+              {% endfor %}
+              <span class="conf-sub">{{ sub_name | downcase }}</span>
+              {% endfor %}
+            </div>
+          </div>
+          <hr />
+        </div>
+        {% endif %}
+        {% endfor %}
+
+        {% if tba_count == 0 %}
+        <div class="meta">No TBA conferences right now.</div>
+        {% endif %}
+      </div>
+
+      <footer>{% include footer.html %}</footer>
+      <br /><br />
+    </div>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -79,8 +79,17 @@
         {% assign year= "now" | date: "%Y" | plus: 0 %}
         <div id="coming_confs">
           {% for conf in site.data.conferences %}
-          <!-- Show this year or future events (year is computed above) -->
-          {% if conf.year >= year %}
+          <!-- Show this year or future events with complete metadata -->
+          {% assign deadline_value = conf.deadline | append: "" | upcase %}
+          {% assign date_value = conf.date | append: "" | upcase %}
+          {% assign place_value = conf.place | append: "" | upcase %}
+          {% assign start_value = conf.start | append: "" %}
+          {% assign end_value = conf.end | append: "" %}
+          {% assign has_tba = false %}
+          {% if deadline_value contains "TBA" or deadline_value contains "TBD" or date_value contains "TBA" or date_value contains "TBD" or place_value contains "TBA" or place_value contains "TBD" or start_value == "" or end_value == "" %}
+          {% assign has_tba = true %}
+          {% endif %}
+          {% if conf.year >= year and has_tba == false %}
           <div
             id="{{conf.id}}"
             class="ConfItem {% for sub in conf.sub %} {{sub}}-conf {% endfor %}"


### PR DESCRIPTION
Hi maintainers, I’m Primo from the HKUST MC2 Lab. Thank you for building and maintaining this HCI conference deadline website.

At the request of our lab members, we prepared the following updates:

Added additional conferences that many HCI researchers frequently submit to, including ACM MM, SIGGRAPH, IDC, NIME, PDC, ArtsIT, and IMX.
Updated this year’s entries for ACM C&C and CSCW 2026.
Updated README with new tags: CG, GAMES, MM, and MUSIC.
Added a /tba/ page and moved conferences with incomplete information out of the homepage main list into the TBA page.
Fixed the navigation entry and homepage filtering logic.
Could you please review the code and run tests/checks? If everything is compliant, we would be very happy to contribute these changes.

Thank you again for your work.