### PR TITLE
Fix deadline and filter handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ To add or update a deadline:
 - [deadlines.openlifescience.ai (Healthcare domain conferences and workshops)][16] by @monk1337
 - [hci-deadlines.github.io (Human-Computer Interaction conferences)][17] by @makinteract
 - [ds-deadlines.github.io (Distributed Systems, Event-based Systems, Performance, and Software Engineering conferences)][18] by @ds-deadlines
+- [https://deadlines.cpusec.org/ (Computer Architecture-Security conferences)][19] by @hoseinyavarzadeh
 
 ## License
 
@@ -81,3 +82,4 @@ It uses:
 [16]: https://deadlines.openlifescience.ai/
 [17]: https://hci-deadlines.github.io/
 [18]: https://ds-deadlines.github.io
+[19]: https://deadlines.cpusec.org/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ To add or update a deadline:
 - [pythondeadlin.es][15] by @jesperdramsch
 - [deadlines.openlifescience.ai (Healthcare domain conferences and workshops)][16] by @monk1337
 - [hci-deadlines.github.io (Human-Computer Interaction conferences)][17] by @makinteract
+- [ds-deadlines.github.io (Distributed Systems, Event-based Systems, Performance, and Software Engineering conferences)][18] by @ds-deadlines
 
 ## License
 
@@ -79,3 +80,4 @@ It uses:
 [15]: https://pythondeadlin.es/
 [16]: https://deadlines.openlifescience.ai/
 [17]: https://hci-deadlines.github.io/
+[18]: https://ds-deadlines.github.io

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ To add or update a deadline:
 - [hci-deadlines.github.io (Human-Computer Interaction conferences)][17] by @makinteract
 - [ds-deadlines.github.io (Distributed Systems, Event-based Systems, Performance, and Software Engineering conferences)][18] by @ds-deadlines
 - [https://deadlines.cpusec.org/ (Computer Architecture-Security conferences)][19] by @hoseinyavarzadeh
+- [se-deadlines.github.io (Software engineering conferences)][20] by @sivanahamer and @imranur-rahman
 
 ## License
 
@@ -83,3 +84,4 @@ It uses:
 [17]: https://hci-deadlines.github.io/
 [18]: https://ds-deadlines.github.io
 [19]: https://deadlines.cpusec.org/
+[20]: https://se-deadlines.github.io/

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ To add or update a deadline:
 - [hci-deadlines.github.io (Human-Computer Interaction conferences)][17] by @makinteract
 - [ds-deadlines.github.io (Distributed Systems, Event-based Systems, Performance, and Software Engineering conferences)][18] by @ds-deadlines
 - [https://deadlines.cpusec.org/ (Computer Architecture-Security conferences)][19] by @hoseinyavarzadeh
+- [awesome-mlss (Machine Learning Summer Schools)][20] by @sshkhr and @gmberton
 
 ## License
 
@@ -83,3 +84,4 @@ It uses:
 [17]: https://hci-deadlines.github.io/
 [18]: https://ds-deadlines.github.io
 [19]: https://deadlines.cpusec.org/
+[20]: https://awesome-mlss.com/

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: CVPR
+  year: 2025
+  id: cvpr25
+  link: https://cvpr.thecvf.com/Conferences/2025
+  deadline: '2024-11-15 06:59:59'
+  abstract_deadline: '2024-11-08 06:59:59'
+  timezone: UTC-0
+  place: Nashville, Tennessee, USA
+  date: June 10-17, 2025
+  start: 2025-06-10
+  end: 2025-06-17
+  hindex: 389
+  sub: CV
+  note: Mandatory paper registration deadline on November 07, 2023. More info <a href='https://cvpr.thecvf.com/Conferences/2025'>here</a>.
+
 - title: NAACL
   year: 2025
   id: naacl25

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: AISTATS
+  year: 2025
+  id: aistats2025
+  link: https://aistats.org/aistats2025/index.html
+  deadline: '2024-10-10 23:59:59'
+  timezone: UTC-12
+  place: Phuket, Thailand
+  date: May 3 - May 5, 2025
+  start: 2025-05-03
+  end: 2025-05-05
+  hindex: 100
+  sub: ['AI', 'Statistic', 'ML', 'AP']
+  note: Abstract deadline on October 3, 2024. More info <a href='https://aistats.org/aistats2025/call-for-papers.html'>here</a>
+
 - title: NAACL
   year: 2025
   id: naacl25
@@ -5,7 +19,7 @@
   deadline: '2024-10-15 23:59:59'
   timezone: UTC-12
   place: Albuquerque, New Mexico, USA
-  date: April 29- May 4, 2024
+  date: April 29 - May 4, 2024
   start: 2025-04-29
   end: 2025-05-04
   hindex: 132

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,15 +1,16 @@
 - title: AISTATS
   year: 2025
-  id: aistats2025
+  id: aistats25
   link: https://aistats.org/aistats2025/index.html
   deadline: '2024-10-10 23:59:59'
+  abstract_deadline: '2024-10-03 23:59:59'
   timezone: UTC-12
   place: Phuket, Thailand
-  date: May 3 - May 5, 2025
+  date: May 03-05, 2025
   start: 2025-05-03
   end: 2025-05-05
   hindex: 100
-  sub: ['AI', 'Statistic', 'ML', 'AP']
+  sub: ML
   note: Abstract deadline on October 3, 2024. More info <a href='https://aistats.org/aistats2025/call-for-papers.html'>here</a>
 
 - title: CVPR

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -18,7 +18,7 @@
   link: https://cvpr.thecvf.com/Conferences/2025
   deadline: '2024-11-15 06:59:59'
   abstract_deadline: '2024-11-08 06:59:59'
-  timezone: UTC-0
+  timezone: GMT
   place: Nashville, Tennessee, USA
   date: June 10-17, 2025
   start: 2025-06-10

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -714,7 +714,7 @@
   full_name: International Conference on Pattern Recognition and Artificial Intelligence
   link: http://icprai2024.org/
   deadline: '2024-01-05 23:59:59'
-  timezone: UTC+9
+  timezone: Asia/Seoul
   place: Jeju Island, South Korea
   date: Jun 18-21, 2024
   start: 2024-06-18
@@ -849,6 +849,7 @@
   hindex: 38
   note: Submission via ACL Rolling Review, commitment date 2023-12-20
   sub: NLP
+
 
 - title: 3DV
   year: 2024
@@ -1399,7 +1400,7 @@
   full_name: IEEE International Conference on Data Mining (ICDM) 
   link: https://icdm22.cse.usf.edu/
   deadline: '2022-06-10 23:59:00'
-  timezone: PDT
+  timezone: America/New_York
   place: Orlando, Florida, USA
   date: November 30 - December 3, 2022
   start: 2022-11-30
@@ -2573,7 +2574,7 @@
   link: https://www.cloud-conf.net/icdm2023/
   deadline: '2023-07-01 23:59:00'
   abstract_deadline: '2023-07-01 23:59:00'
-  timezone: GMT+8
+  timezone: Asia/Shanghai
   place: Shanghai, China
   date: December 1-4, 2023
   start: 2023-12-01
@@ -2632,7 +2633,7 @@
   full_name: AI World Barcelona - Generative AI Conference # full conference name
   link: https://ai-world-barcelona.com
   deadline: '2023-06-07 23:59:59'
-  timezone: GMT+2
+  timezone: Europe/Madrid
   place: Barcelona, Spain
   date: September, 7-8, 2023
   start: 2023-09-07
@@ -2646,7 +2647,7 @@
   full_name: International Conference on Speech and Computer # full conference name
   link: https://specom2024.ftn.uns.ac.rs
   deadline: '2024-07-01 23:59:59'
-  timezone: GMT+1
+  timezone: Europe/Belgrade
   place: Belgrade, Serbia
   date: November, 25-28, 2024
   start: 2024-11-25
@@ -2697,17 +2698,3 @@
   sub: ML
   note: Check the conference website for tutorials, contributions to the journal track and workshop deadlines
 
-
-- title: 3DV
-  year: 2025
-  id: 3dv25
-  full_name: International Conference on 3D Vision
-  link: https://3dvconf.github.io/2025/
-  deadline: '2024-08-12 23:59:59'
-  timezone: UTC-0
-  place: Singapore
-  date: March, 25-28, 2025
-  start: '2025-03-25'
-  end: '2025-03-28'
-  sub: CV
-  hindex: 47

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,6 +1,6 @@
 - title: KIL
   year: 2024
-  Id: kil24
+  id: kil24
   full_name: KDD Workshop on Knowledge-infused Learning
   link: https://kil-workshop.github.io/
   deadline: '2024-05-25 23:59:59'

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: ISMIR
+  year: 2024
+  id: ismir24
+  link: https://ismir2024.ismir.net/
+  deadline: '2024-04-12 23:59:59'
+  abstract_deadline: '2024-04-05 23:59:59'
+  timezone: UTC-12
+  place: San Francisco, California, USA
+  date: November 10-14, 2024
+  start: 2024-11-10
+  end: 2024-11-14
+  hindex: 43
+  sub: SP
+  note: Mandatory abstract deadline on April 5th, 2024. More info <a href='https://ismir2024.ismir.net/authors/call-for-papers/'>here</a>.
+
 - title: EMNLP
   year: 2024
   id: emnlp24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -12,7 +12,20 @@
   hindex: 254
   sub: ML
 
-
+- title: MICCAI
+  year: 2024
+  id: miccai2024
+  link: https://conferences.miccai.org/2024/en/
+  deadline: '2024-03-07 23:59:59'
+  timezone: America/Los_Angeles
+  place: Marrakech, Morocco
+  date: October 6 - October 10, 2024
+  start: 2024-10-06
+  end: 2024-10-10
+  hindex: 78
+  sub: CV
+  note: More info <a href='https://conferences.miccai.org/2024/'>here</a>.
+  
 - title: SIGIR
   year: 2024
   id: sigir24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: SPAICE
+  year: 2024
+  id: spaice24
+  full_name: 1st ESA Conference on AI in and for Space
+  link: https://spaice.esa.int/
+  deadline: '2024-05-19 23:59:59'
+  timezone: UTC+2
+  place: ECSAT, Harwell, United Kingdom
+  date: September 17-19, 2024
+  start: 2024-09-17
+  end: 2024-09-19
+  sub: ML
+  note: Best papers will be selected for special issues on AI and space in IAA Acta Astronautica and Springer Astrodynamics. More info <a href='https://spaice.esa.int/call-for-papers/'>here</a>.
+
 - title: EMNLP
   year: 2024
   id: emnlp24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: KIL
+  year: 2024
+  Id: kil24
+  full_name: KDD Workshop on Knowledge-infused Learning
+  link: https://kil-workshop.github.io/
+  deadline: '2024-05-25 23:59:59'
+  timezone: UTC-12
+  place: Barcelona, Spain
+  date: August 25, 2024
+  start: 2024-08-20
+  end: 2024-08-25
+  sub: ['NLP', 'ML', 'DM']
+  Note: More info <a href='https://kil-workshop.github.io/'>here</a>
+
 - title: EMNLP
   year: 2024
   id: emnlp24
@@ -10,7 +24,7 @@
   end: 2024-11-16
   sub: NLP
   note: More info <a href='https://2024.emnlp.org/calls/main_conference_papers/'>here</a>.
-
+  
 - title: CIKM
   year: 2024
   id: CIKM24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -9,7 +9,7 @@
   data: October 21 - October 25, 2024
   start: 2024-10-21
   end: 2024-10-25
-  sub: DM, KR
+  sub: ['DM', 'KR']
   note: Mandatory abstract deadline on May 13, 2024. More info <a href='https://cikm2024.org/call-for-papers/'>here</a>.
 
 - title: NeurIPS

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,19 @@
 ---
+- title: RSS
+  year: 2024
+  id: rss24
+  link: https://roboticsconference.org/2024
+  deadline: '2024-02-02 23:59:59'
+  timezone: UTC-12
+  place: Delft, Netherlands
+  date: July 15-19, 2024
+  start: 2024-07-15
+  end: 2024-07-19
+  hindex: 61
+  sub: RO
+  note: Optional supplementary material deadline on February 08, 2024. More info <a href='https://roboticsconference.org/2024'>here</a>.
+
+
 - title: ICML
   year: 2024
   id: icml24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,19 @@
 ---
+- title: SIGIR
+  year: 2024
+  id: sigir24
+  link: https://sigir-2024.github.io
+  deadline: '2024-01-25 23:59:00'
+  abstract_deadline: '2024-01-18 23:59:00'
+  timezone: UTC-12
+  place: Washington D.C., USA
+  date: July 14-18, 2023
+  start: 2024-07-14
+  end: 2024-07-18
+  hindex: 66
+  sub: DM
+  note: Mandatory abstract deadline on January 18, 2024. More info <a href='https://sigir-2024.github.io/call_for_papers.html'>here</a>.
+  
 - title: IJCAI-PRICAI
   year: 2024
   id: ijcai24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -179,7 +179,7 @@
   year: 2024
   id: icml24
   link: https://icml.cc/Conferences/2024
-  deadline: '2024-02-01 11:59:00'
+  deadline: '2024-02-01 23:59:59'
   timezone: UTC-12
   place: Vienna, Austria
   date: July 21-27, 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -163,7 +163,8 @@
   year: 2024
   id: rlc24
   link: https://rl-conference.cc/
-  deadline: '2024-03-01 23:59:59'
+  deadline: '2024-03-08 23:59:59'
+  abstract_deadline: '2024-03-01 23:59:59'
   timezone: UTC-12
   place: Amherst, Massachusetts, USA
   date: August 09-12, 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,17 @@
 ---
+- title: AISTATS
+  year: 2024
+  id: aistats24
+  link: https://www.aistats.org/aistats2024/
+  deadline: '2023-10-13 23:59:59'
+  timezone: UTC-12
+  place: Valencia, Spain
+  date: May 02-04, 2024
+  start: 2024-05-02
+  end: 2024-05-04
+  hindex: 91
+  sub: ML
+  note: Mandatory abstract deadline on Oct 6, 2023. More info <a href='https://aistats.org/aistats2024/dates.html'>here</a>.
 
 - title: ICASSP
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,15 @@
+- title: AABI
+  year: 2024
+  id: aabi24
+  full_name: Advances in Approximate Bayesian Inference
+  link: http://approximateinference.org/
+  deadline: '2024-03-29 23:59:00'
+  timezone: UTC-12
+  place: Vienna, Austria
+  date: July, 21, 2024
+  sub: ML
+  note: "The deadline for submissions to the proceedings and workshop tracks is 29 March. The deadline for submitting a recently published paper to AABI's fast track is 10 May."
+
 - title: CoRL
   year: 2024
   id: corl24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2311,7 +2311,7 @@
   id: mipr24  # title as lower case + last two digits of year
   full_name: International Conference on Multimedia Information Processing and Retrieval # full conference name
   link: https://sites.google.com/view/mipr2024
-  deadline: '2024-03-15 23:59:59'
+  deadline: '2024-04-15 23:59:59'
   timezone: UTC-7
   place: San Jose, USA
   date: August, 07-09, 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,17 @@
 ---
+- title: ICASSP
+  year: 2024
+  id: icassp24
+  link: https://2024.ieeeicassp.org/
+  deadline: '2023-09-06 23:59:59'
+  timezone: UTC-12
+  place: Seoul, Korea
+  date: April 14-19, 2024
+  start: 2024-04-14
+  end: 2024-04-19
+  hindex: 123
+  sub: SP
+
 - title: WACV
   year: 2024
   id: wacv24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,18 @@
 ---
+- title: ECCV
+  year: 2024
+  id: eccv24
+  link: https://eccv2024.ecva.net/
+  deadline: '2024-03-07 23:59:00'
+  timezone: UTC-12
+  place: Milano, Italy
+  date: September 29 - October 04, 2024
+  start: 2024-09-29
+  end: 2024-10-04
+  hindex: 238
+  sub: CV
+  note: Abstract deadline on February 29, 2024. More info <a href='https://eccv2024.ecva.net/'>here</a>.
+
 - title: ICPRAI
   year: 2024
   id: icprai24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -256,7 +256,7 @@
   date: October 7-9, 2024
   start: 2024-10-07
   end: 2024-10-09
-  sub: ML
+  sub: ['NLP', 'ML']
   note: Mandatory abstract deadline on March 22, 2024. More info <a href='https://colmweb.org/cfp.html'>here</a>.
 
 - title: IJCAI

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: CIKM
+  year: 2024
+  id: CIKM24
+  link: https://cikm2024.org/
+  deadline: '2024-05-20 23:59:59'
+  abstract_deadline: '2024-05-13 23:59:59'
+  timezone: UTC-12
+  place: Boise, Idaho, USA
+  data: October 21 - October 25, 2024
+  start: 2024-10-21
+  end: 2024-10-25
+  sub: DM, KR
+  note: Mandatory abstract deadline on May 13, 2024. More info <a href='https://cikm2024.org/call-for-papers/'>here</a>.
+
 - title: AABI
   year: 2024
   id: aabi24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,18 @@
 ---
+- title: CHIL
+  year: 2024
+  id: CHIL24
+  full_name: Conference on Health, Inference, and Learning
+  link: https://www.chilconference.org/index.html
+  deadline: '2024-02-05 23:59:59'
+  timezone: America/New_York
+  place: New York, New York
+  date: June, 27-28, 2024
+  start: 2024-06-27
+  end: 2024-06-28
+  sub: ML
+  note: Please check the website for the latest updates.
+
 - title: SaTML
   year: 2024
   id: satml24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,18 @@
 ---
+- title: ICML
+  year: 2024
+  id: icml24
+  link: https://icml.cc/Conferences/2024
+  deadline: '2024-02-01 11:59:00'
+  timezone: UTC-12
+  place: Vienna, Austria
+  date: July 21-27, 2024
+  start: 2024-07-21
+  end: 2024-07-27
+  hindex: 254
+  sub: ML
+
+
 - title: SIGIR
   year: 2024
   id: sigir24
@@ -613,7 +627,7 @@
 - title: ICML
   year: 2023
   id: icml23
-  link: https://icml.cc/
+  link: https://icml.cc/Conferences/2023
   deadline: '2023-01-26 11:59:00'
   timezone: America/Los_Angeles
   place: Hawai'i, USA

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,17 @@
 ---
+- title: COLM
+  year: 2024
+  id: colm24
+  full_name: 1st Conference on Language Modeling
+  link: https://colmweb.org/
+  deadline: '2024-03-15 23:59:59'
+  abstract_deadline: '2024-03-8 23:59:59'
+  timezone: UTC-12
+  place: TBD
+  date: October, 2024
+  sub: NLP
+  note: Mandatory abstract deadline on March 8, 2024. More info [here](https://colmweb.org/cfp.html)
+
 - title: IJCAI-PRICAI
   year: 2024
   id: ijcai24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,16 @@
+- title: IROS
+  year: 2024
+  id: iros24
+  link: https://iros2024-abudhabi.org/
+  deadline: '2024-03-01 23:59:59'
+  timezone: America/Los_Angeles
+  place: Abu Dhabi, UAE
+  date: October 14-18, 2024
+  start: 2024-10-14
+  end: 2024-10-18
+  hindex: 80
+  sub: RO
+
 - title: KR
   year: 2024
   id: kr24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2,7 +2,7 @@
   year: 2024
   id: corl24
   link: https://sites.google.com/robot-learning.org/corl2024/
-  deadline: '2023-06-06 23:59:00'
+  deadline: '2024-06-06 23:59:00'
   timezone: UTC-12
   place: Munich, Germany
   date: November 06-09, 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,19 @@
 ---
+- title: ICLR
+  year: 2024
+  id: iclr24
+  link: https://iclr.cc/Conferences/2024
+  deadline: '2023-09-28 23:59:59'
+  abstract_deadline: '2023-09-21 23:59:59'
+  timezone: UTC-12
+  place: Vienna, Austria
+  date: May 07-11, 2024
+  start: 2024-05-07
+  end: 2024-05-11
+  hindex: 286
+  sub: ML
+  note: Mandatory abstract deadline on September 21, 2023. More info <a href='https://iclr.cc/Conferences/2024/CallForPapers'>here</a>.
+
 - title: CVPR
   year: 2024
   id: cvpr24
@@ -488,14 +503,14 @@
 - title: ICLR
   year: 2023
   id: iclr23
-  link: https://iclr.cc/
+  link: https://iclr.cc/Conferences/2023
   deadline: '2022-09-28 23:59:59'
   abstract_deadline: '2022-09-21 23:59:59'
   timezone: UTC-12
   place: Kigali, Rwanda
   date: May 01-05, 2023
   start: 2023-05-01
-  end: 2022-05-05
+  end: 2023-05-05
   hindex: 286
   sub: ML
   note: Mandatory abstract deadline on September 21, 2022. More info <a href='https://iclr.cc/Conferences/2023/CallForPapers'>here</a>.
@@ -1247,7 +1262,7 @@
 - title: ICLR
   year: 2022
   id: iclr22
-  link: https://iclr.cc/
+  link: https://iclr.cc/Conferences/2022
   deadline: '2021-10-05 17:00:00'
   abstract_deadline: '2021-09-28 17:00:00'
   timezone: UTC-7

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: SIGGRAPH
+  year: 2024
+  id: siggraph24
+  link: https://s2024.siggraph.org/
+  deadline: '2023-01-24 22:00:00'
+  abstract_deadline: '2022-01-23 22:00:00'
+  timezone: GMT
+  place: Denver, USA
+  date: July 28 - August 1, 2024
+  start: 2024-07-28
+  end: 2024-08-01
+  sub: CG
+  note: Mandatory abstract deadline on Jan 23, 2024. More info <a href='https://s2024.siggraph.org/program/technical-papers/'>here</a>.
+
 - title: UAI
   year: 2024
   id: uai24
@@ -2035,7 +2049,7 @@
   sub: ML
   note: The workshop is a collaboration between NASSMA organisation, Deepmind and UM6P. NASSMA is an NGO working toward the promotion of STEM and AI education and research in MENA region. 
 
-- title: SIGGRAPH 2023
+- title: SIGGRAPH
   year: 2023
   id: siggraph23
   link: https://s2023.siggraph.org/

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,7 +1,7 @@
 - title: CoRL
   year: 2024
   id: corl24
-  link: https://sites.google.com/robot-learning.org/corl2024/
+  link: https://corl.org
   deadline: '2023-06-06 23:59:00'
   timezone: UTC-12
   place: Munich, Germany

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -7,7 +7,7 @@
   abstract_deadline: '2024-01-18 23:59:00'
   timezone: UTC-12
   place: Washington D.C., USA
-  date: July 14-18, 2023
+  date: July 14-18, 2024
   start: 2024-07-14
   end: 2024-07-18
   hindex: 66

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -251,8 +251,8 @@
   id: CHIL24
   full_name: Conference on Health, Inference, and Learning
   link: https://www.chilconference.org/index.html
-  deadline: '2024-02-05 23:59:59'
-  timezone: America/New_York
+  deadline: '2024-02-16 23:59:59'
+  timezone: UTC-14
   place: New York, New York
   date: June, 27-28, 2024
   start: 2024-06-27

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,18 @@
 ---
+- title: ECAI
+  year: 2024
+  id: ecai24
+  link: https://www.ecai2024.eu/
+  deadline: '2024-04-25 23:59:59'
+  abstract_deadline: '2024-04-19 23:59:59'
+  timezone: UTC-12
+  place: Santiago de Compostela, Spain
+  date: October 19-24, 2024
+  start: 2024-10-19
+  end: 2024-10-24
+  sub: ML
+  note: Mandatory abstract deadline on April 19, 2024. More info <a href='https://www.ecai2024.eu/calls/main-track'>here</a>.
+
 - title: RLC
   year: 2024
   id: rlc24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,21 @@
 ---
+
+- title: ICAPS
+  year: 2024
+  id: icaps24
+  link: https://icaps24.icaps-conference.org/
+  deadline: '2023-12-13 23:59:59'
+  abstract_deadline: '2023-12-07 23:59:59'
+  timezone: UTC-12
+  place: Banff, Canada
+  date: Jun 01-06, 2024
+  start: 2024-06-01
+  end: 2024-06-06
+  hindex: 32
+  sub: AP
+  note: Mandatory abstract deadline on December 07, 2023. More info <a href='https://icaps24.icaps-conference.org/'>here</a>.
+
+
 - title: NAACL
   year: 2024
   id: naacl24
@@ -547,7 +564,7 @@
   place: Prague, Czech Republic
   date: Jul 08-13, 2023
   start: 2023-07-08
-  end: 2022-07-13
+  end: 2023-07-13
   hindex: 27
   sub: AP
   note: Mandatory abstract deadline on November 25, 2022. More info <a href='https://icaps23.icaps-conference.org/'>here</a>.

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,19 @@
 ---
+- title: SaTML
+  year: 2024
+  id: satml24
+  full_name: IEEE Conference on Secure and Trustworthy Machine Learning
+  link: https://satml.org/
+  deadline: '2023-10-11 23:59:59'
+  abstract_deadline: '2023-10-04 23:59:59'
+  timezone: UTC-12
+  place: Toronto, Canada
+  date: April 2024
+  start: 2024-04-01
+  end: 2024-04-01
+  sub: ML
+  note: Check the website for exact conference dates.
+
 - title: ECCV
   year: 2024
   id: eccv24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -172,7 +172,7 @@
   id: icprai24
   full_name: International Conference on Pattern Recognition and Artificial Intelligence
   link: http://icprai2024.org/
-  deadline: '2023-12-15 23:59:59'
+  deadline: '2024-01-05 23:59:59'
   timezone: UTC+9
   place: Jeju Island, South Korea
   date: Jun 18-21, 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,18 @@
 ---
+
+- title: HRI
+  year: 2024
+  id: hri24
+  link: https://humanrobotinteraction.org/2024/
+  deadline: '2023-09-29 23:59:59'
+  timezone: UTC-12
+  place: Boulder, Colorado, USA
+  date: March 11-14, 2024
+  start: 2024-03-11
+  end: 2024-03-14
+  hindex: 55
+  sub: RO
+
 - title: WACV
   year: 2024
   id: wacv24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -18,7 +18,7 @@
   id: aaaisss24cfm  # title as lower case + last two digits of year
   full_name: AAAI 2024 Spring Symposium on Clinical Foundation Models  # full conference name
   link: https://clinicalfoundationmodels.github.io/
-  deadline: '2024-01-05 23:59:59'
+  deadline: '2024-01-26 23:59:59'
   timezone: UTC-12
   place: Stanford, USA
   date: March, 25-27, 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,18 @@
 ---
+- title: NAACL
+  year: 2024
+  id: naacl24
+  link: https://2024.naacl.org/
+  deadline: '2023-12-15 23:59:00'
+  timezone: UTC-12
+  place: Mexico City, Mexico
+  date: June 16-21, 2024
+  start: 2024-06-16
+  end: 2024-06-21
+  hindex: 133
+  sub: NLP
+  note: All submissions must be done through ARR. More info <a href='https://2024.naacl.org/calls/papers/'>here</a>.
+
 - title: CSCW
   year: 2024
   id: cscw24_january

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -16,8 +16,8 @@
   year: 2024
   id: siggraph24
   link: https://s2024.siggraph.org/
-  deadline: '2023-01-24 22:00:00'
-  abstract_deadline: '2022-01-23 22:00:00'
+  deadline: '2024-01-24 22:00:00'
+  abstract_deadline: '2024-01-23 22:00:00'
   timezone: GMT
   place: Denver, USA
   date: July 28 - August 1, 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -77,6 +77,19 @@
   end: 2024-08-12
   sub: ML
 
+- title: KDD
+  year: 2022
+  id: kdd24  # title as lower case + last two digits of year
+  link: https://kdd2024.kdd.org/
+  deadline: 2024-02-08 23:59:59
+  abstract_deadline: 2024-02-01 23:59:59
+  timezone: UTC-12
+  place: Barcelona, Spain
+  date: August 25-29, 2024
+  start: 2024-08-25
+  end: 2024-08-29
+  sub: DM
+
 - title: RSS
   year: 2024
   id: rss24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,17 @@
 ---
+- title: ICPRAI
+  year: 2024
+  id: icprai24
+  full_name: International Conference on Pattern Recognition and Artificial Intelligence
+  link: http://icprai2024.org/
+  deadline: '2023-12-15 23:59:59'
+  timezone: UTC+9
+  place: Jeju Island, South Korea
+  date: Jun 18-21, 2024
+  start: 2024-06-18
+  end: 2024-06-21
+  sub: ML
+  note: Soliciting both regular papers and work-in-progress papers. More info <a href='http://icprai2024.org/'>here</a>.
 
 - title: ICAPS
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2150,3 +2150,17 @@
   end: 2023-09-08
   sub: NLP
   note: Explore cutting-edge AI topics like ChatGPT, AutoGPT, DALL-E, Midjourney and more at AI World Barcelona — the world's largest generative AI conference.
+
+- title: SPECOM
+  year: 2024
+  id: specom24  # title as lower case + last two digits of year
+  full_name: International Conference on Speech and Computer # full conference name
+  link: https://specom2024.ftn.uns.ac.rs
+  deadline: '2024-07-01 23:59:59'
+  timezone: GMT+1
+  place: Belgrade, Serbia
+  date: November, 25-28, 2023
+  start: 2023-11-25
+  end: 2023-11-28
+  sub: SP
+  note: Check the conference website for workshop and demo deadlines.

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2261,3 +2261,17 @@
   end: 2024-08-09
   sub: ML
   note: Check the conference website for paper review available and notification of acceptance date.
+
+  - title: AIware
+  year: 2024
+  id: aiware24  # title as lower case + last two digits of year
+  full_name: ACM International Conference on AIware  # full conference name
+  link: https://2024.aiwareconf.org/#
+  deadline: '2024-03-29 23:59:59'
+  timezone: UTC-3
+  place: Porto de Galinhas, Brazil
+  date: July, 15-16, 2024
+  start: 2024-07-15
+  end: 2024-07-16
+  sub: ML
+  note: Check the conference website for details the Challenge Track, Industry Statements and Demo Track, and Late Breaking Arxiv Track.

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: NeurIPS
+  year: 2024
+  id: neurips24
+  full_name: Conference on Neural Information Processing Systems
+  link: https://nips.cc/Conferences/2024
+  deadline: '2024-05-22 20:00:00'
+  timezone: UTC
+  place: Vancouver, Canada
+  date: December 9 - December 15, 2024
+  start: 2024-12-09
+  end: 2023-12-15
+  sub: ML
+  note: Abstract deadline to be announced
+
 - title: AABI
   year: 2024
   id: aabi24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2262,7 +2262,7 @@
   sub: ML
   note: Check the conference website for paper review available and notification of acceptance date.
 
-  - title: AIware
+- title: AIware
   year: 2024
   id: aiware24  # title as lower case + last two digits of year
   full_name: ACM International Conference on AIware  # full conference name

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,18 @@
 ---
+- title: NAACL
+  year: 2024
+  id: naacl24
+  link: https://2024.naacl.org
+  deadline: '2023-12-15 23:59:59'
+  timezone: UTC-12
+  place: Mexico City, Mexico
+  date: June 16-21, 2024
+  start: 2024-06-16
+  end: 2024-06-21
+  hindex: 133
+  note: Submission via ACL Rolling Review, commitment date 2024-02-20
+  sub: NLP
+  
 - title: CSCW
   year: 2024
   id: cscw24_january
@@ -91,6 +105,7 @@
   date: March 17-22, 2024
   start: 2024-03-17
   end: 2024-03-22
+  hindex: 38
   note: Submission via ACL Rolling Review, commitment date 2023-12-20
   sub: NLP
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -101,17 +101,17 @@
   deadline: '2024-03-01 23:59:59'
   timezone: UTC-12
   place: Amherst, Massachusetts, USA
-  date: Aug 09-12, 2024
+  date: August 09-12, 2024
   start: 2024-08-09
   end: 2024-08-12
   sub: ML
 
 - title: KDD
-  year: 2022
+  year: 2024
   id: kdd24  # title as lower case + last two digits of year
   link: https://kdd2024.kdd.org/
-  deadline: 2024-02-08 23:59:59
-  abstract_deadline: 2024-02-01 23:59:59
+  deadline: '2024-02-08 23:59:59'
+  abstract_deadline: '2024-02-01 23:59:59'
   timezone: UTC-12
   place: Barcelona, Spain
   date: August 25-29, 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -243,7 +243,7 @@
   year: 2024
   id: lreccoling24
   full_name: The 2024 Joint International Conference on Computational Linguistics, Language Resources and Evaluation
-  link: https://lrec-coling-2024.lrec-conf.org/
+  link: https://lrec-coling-2024.org
   deadline: '2023-10-13 23:59:59'
   timezone: UTC-12
   place: Torino, Italy

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2247,3 +2247,17 @@
   end: 2024-11-28
   sub: SP
   note: Check the conference website for workshop and demo deadlines.
+
+- title: MIPR
+  year: 2024
+  id: mipr24  # title as lower case + last two digits of year
+  full_name: International Conference on Multimedia Information Processing and Retrieval # full conference name
+  link: https://sites.google.com/view/mipr2024
+  deadline: '2024-03-15 23:59:59'
+  timezone: UTC-7
+  place: San Jose, USA
+  date: August, 07-09, 2024
+  start: 2024-08-07
+  end: 2024-08-09
+  sub: SP
+  note: Check the conference website for paper review available and notification of acceptance date.

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2340,7 +2340,7 @@
   full_name: International Conference on Automated Machine Learning  # full conference name
   link: https://2024.automl.cc/
   deadline: '2024-02-29 23:59:59'
-  deadline: '2024-02-26 23:59:59'
+  abstract_deadline: '2024-02-26 23:59:59'
   timezone: UTC-12
   place: Paris, France
   date: September, 09-12, 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -119,10 +119,10 @@
   sub: NLP
   note: Mandatory abstract deadline on March 8, 2024. More info <a href='https://colmweb.org/cfp.html'>here</a>.
 
-- title: IJCAI-PRICAI
+- title: IJCAI
   year: 2024
   id: ijcai24
-  full_name: International Joint Conference on Artificial Intelligence and Pacific Rim International Conference on Artificial Intelligence
+  full_name: International Joint Conference on Artificial Intelligence
   link: https://ijcai24.org/
   deadline: '2024-01-17 23:59:59'
   abstract_deadline: '2024-01-10 23:59:59'

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,16 @@
 ---
+- title: RLC
+  year: 2024
+  id: rlc24
+  link: https://rl-conference.cc/
+  deadline: '2024-03-01 23:59:59'
+  timezone: UTC-12
+  place: Amherst, Massachusetts, USA
+  date: Aug 09-12, 2024
+  start: 2024-08-09
+  end: 2024-08-12
+  sub: ML
+
 - title: RSS
   year: 2024
   id: rss24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,17 @@
 ---
+- title: CoLLAs
+  year: 2024
+  id: collas24
+  link: https://lifelong-ml.cc
+  deadline: '2024-02-15 23:59:59'
+  abstract_deadline: '2024-02-09 23:59:59'
+  timezone: UTC-12
+  place: Pisa, Italy
+  date: July 29 - August 01, 2024
+  start: 2024-07-29
+  end: 2024-08-01
+  sub: ML
+
 - title: ECAI
   year: 2024
   id: ecai24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -10,7 +10,7 @@
   start: 2024-12-09
   end: 2023-12-15
   sub: ML
-  note: Abstract deadline to be announced
+  note: Mandatory abstract deadline on May 15, 2024
 
 - title: AABI
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -10,7 +10,7 @@
   start: 2024-07-21
   end: 2024-07-21
   sub: ML
-  note: "Co-located with ICML 2024. Submission deadlines are March 29 (proceedings and workshop track) and May 10 (fast track). More info <a href="http://approximateinference.org/call/index.html">here</a>"
+  note: Co-located with ICML 2024. Submission deadlines are March 29 (proceedings and workshop track) and May 10 (fast track). More info <a href="http://approximateinference.org/call/index.html">here</a>
 
 - title: CoRL
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -158,7 +158,7 @@
   id: iclr24
   link: https://iclr.cc/Conferences/2024
   deadline: '2023-09-28 23:59:59'
-  abstract_deadline: '2023-09-21 23:59:59'
+  abstract_deadline: '2023-09-23 23:59:59'
   timezone: UTC-12
   place: Vienna, Austria
   date: May 07-11, 2024
@@ -166,7 +166,7 @@
   end: 2024-05-11
   hindex: 286
   sub: ML
-  note: Mandatory abstract deadline on September 21, 2023. More info <a href='https://iclr.cc/Conferences/2024/CallForPapers'>here</a>.
+  note: Mandatory abstract deadline on September 23, 2023. More info <a href='https://iclr.cc/Conferences/2024/CallForPapers'>here</a>.
   
 - title: CVPR
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -103,15 +103,16 @@
   year: 2024
   id: eccv24
   link: https://eccv2024.ecva.net/
-  deadline: '2024-03-07 23:59:00'
-  timezone: UTC-12
+  deadline: '2024-03-07 12:59:00'
+  abstract_deadline: '2024-02-29 12:59:00'
+  timezone: UTC-8
   place: Milano, Italy
   date: September 29 - October 04, 2024
   start: 2024-09-29
   end: 2024-10-04
   hindex: 238
   sub: CV
-  note: Abstract deadline on February 29, 2024. More info <a href='https://eccv2024.ecva.net/'>here</a>.
+  note: More info <a href='https://eccv2024.ecva.net/'>here</a>.
 
 - title: CLeaR
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: MM
+  year: 2024
+  id: mm24
+  link: https://2024.acmmm.org/
+  deadline: '2024-04-08 23:59:59'
+  abstract_deadline: '2024-04-12 23:59:59'
+  timezone: UTC-12
+  place: Melbourne, Australia
+  data: October 28 - November 1, 2024
+  start: 2024-10-28
+  end: 2024-11-01
+  sub: CV
+  note: Mandatory abstract deadline on April 8, 2024. More info <a href='https://2024.acmmm.org/regular-papers'>here</a>.
+
 - title: ACL
   year: 2024
   id: acl24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,16 @@
+- title: EMNLP
+  year: 2024
+  id: emnlp24
+  link: https://2024.emnlp.org/
+  deadline: '2024-06-15 23:59:00'
+  timezone: UTC-12
+  place: Miami, Florida, USA
+  date: November 12-16, 2024
+  start: 2024-11-12
+  end: 2024-11-16
+  sub: NLP
+  note: More info <a href='https://2024.emnlp.org/calls/main_conference_papers/'>here</a>.
+
 - title: CIKM
   year: 2024
   id: CIKM24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -116,7 +116,7 @@
   year: 2024
   id: aistats24
   link: https://www.aistats.org/aistats2024/
-  deadline: '2023-10-13 23:59:59'
+  deadline: '2023-10-16 23:59:59'
   timezone: UTC-12
   place: Valencia, Spain
   date: May 02-04, 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,18 @@
 ---
+- title: CVPR
+  year: 2024
+  id: cvpr24
+  link: https://cvpr.thecvf.com/Conferences/2024
+  deadline: '2023-11-10 23:59:59'
+  abstract_deadline: '2023-11-03 23:59:59'
+  timezone: America/Los_Angeles
+  place: Seattle, Washington, USA
+  date: June 17-21, 2024
+  start: 2024-06-17
+  end: 2024-06-21
+  hindex: 389
+  sub: CV
+
 - title: ICRA
   year: 2024
   id: icra24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2333,3 +2333,19 @@
   end: 2024-07-16
   sub: ML
   note: Check the conference website for details the Challenge Track, Industry Statements and Demo Track, and Late Breaking Arxiv Track.
+
+- title: AutoML
+  year: 2024
+  id: automl24  # title as lower case + last two digits of year
+  full_name: International Conference on Automated Machine Learning  # full conference name
+  link: https://2024.automl.cc/
+  deadline: '2024-02-29 23:59:59'
+  deadline: '2024-02-26 23:59:59'
+  timezone: UTC-12
+  place: Paris, France
+  date: September, 09-12, 2024
+  start: 2024-09-09
+  end: 2024-09-12
+  sub: ML
+  note: Check the conference website for tutorials, contributions to the journal track and workshop deadlines
+

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -317,7 +317,7 @@
   id: lreccoling24
   full_name: The 2024 Joint International Conference on Computational Linguistics, Language Resources and Evaluation
   link: https://lrec-coling-2024.org
-  deadline: '2023-10-13 23:59:59'
+  deadline: '2023-10-20 23:59:59'
   timezone: UTC-12
   place: Torino, Italy
   date: May 20 - May 25, 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2159,8 +2159,8 @@
   deadline: '2024-07-01 23:59:59'
   timezone: GMT+1
   place: Belgrade, Serbia
-  date: November, 25-28, 2023
-  start: 2023-11-25
-  end: 2023-11-28
+  date: November, 25-28, 2024
+  start: 2024-11-25
+  end: 2024-11-28
   sub: SP
   note: Check the conference website for workshop and demo deadlines.

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: AAAI 2024 Spring Symposium on Clinical Foundation Models
+  year: 2024
+  id: aaaisss24cfm  # title as lower case + last two digits of year
+  full_name: AAAI 2024 Spring Symposium on Clinical Foundation Models  # full conference name
+  link: https://clinicalfoundationmodels.github.io/
+  deadline: '2024-01-05 23:59:59'
+  timezone: UTC-12
+  place: Stanford, USA
+  date: March, 25-27, 2024
+  start: 2024-03-25
+  end: 2024-03-27
+  sub: ML
+  note: More info <a href='https://clinicalfoundationmodels.github.io/'>here</a>.
+  
 - title: UAI
   year: 2024
   id: uai24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -99,9 +99,11 @@
 - title: EACL
   year: 2024
   id: eacl24
+  full_name: The 18th Conference of the European Chapter of the Association for Computational Linguistics
+  link: https://2024.eacl.org/
   deadline: '2023-10-15 23:59:59'
   timezone: UTC-12
-  place: Malta
+  place: St. Julians, Malta
   date: March 17-22, 2024
   start: 2024-03-17
   end: 2024-03-22

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,16 @@
 ---
+- title: CLeaR
+  year: 2024
+  id: clear24
+  link: https://www.cclear.cc/2024
+  deadline: '2023-10-27 23:59:59'
+  timezone: UTC-12
+  place: Los Angeles, USA
+  date: April 1 - April 03, 2024
+  start: 2024-04-01
+  end: 2024-04-03
+  sub: ML
+
 - title: ICPRAI
   year: 2024
   id: icprai24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -61,7 +61,7 @@
   abstract_deadline: '2024-04-12 23:59:59'
   timezone: UTC-12
   place: Melbourne, Australia
-  data: October 28 - November 1, 2024
+  date: October 28 - November 1, 2024
   start: 2024-10-28
   end: 2024-11-01
   sub: CV

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2,8 +2,7 @@
 - title: IJCAI-PRICAI
   year: 2024
   id: ijcai24
-  full_name: International Joint Conference on Artificial Intelligence and 
-  Pacific Rim International Conference on Artificial Intelligence
+  full_name: International Joint Conference on Artificial Intelligence and Pacific Rim International Conference on Artificial Intelligence
   link: https://ijcai24.org/
   deadline: '2024-01-17 23:59:59'
   abstract_deadline: '2024-01-10 23:59:59'

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -11,6 +11,20 @@
   end: 2024-03-27
   sub: ML
   note: More info <a href='https://clinicalfoundationmodels.github.io/'>here</a>.
+
+- title: AIA
+  year: 2024
+  id: aia24
+  link: https://aair-lab.github.io/aia2024/
+  deadline: '2023-12-22 23:59:59'
+  timezone: UTC-12
+  place: Stanford, USA  
+  date: March 25-27, 2024
+  start: 2024-03-25
+  end: 2024-03-27
+  hindex: -1
+  sub: ML
+  
   
 - title: SIGGRAPH
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -27,7 +27,7 @@
   sub: ML
   note: More info <a href='https://clinicalfoundationmodels.github.io/'>here</a>.
 
-- title: AIA
+- title: AAAI 2024 Spring Symposium on User-Aligned Assessment of Adaptive AI Systems
   year: 2024
   id: aia24
   link: https://aair-lab.github.io/aia2024/

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -256,7 +256,7 @@
   date: October 7-9, 2024
   start: 2024-10-07
   end: 2024-10-09
-  sub: NLP, ML
+  sub: ML
   note: Mandatory abstract deadline on March 22, 2024. More info <a href='https://colmweb.org/cfp.html'>here</a>.
 
 - title: IJCAI

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -285,7 +285,7 @@
   year: 2024
   id: cvpr24
   link: https://cvpr.thecvf.com/Conferences/2024
-  deadline: '2023-11-10 23:59:59'
+  deadline: '2023-11-17 23:59:59'
   abstract_deadline: '2023-11-03 23:59:59'
   timezone: America/Los_Angeles
   place: Seattle, Washington, USA
@@ -294,6 +294,8 @@
   end: 2024-06-21
   hindex: 389
   sub: CV
+  note: Mandatory paper registration deadline on November 03, 2023 and optional supplementary material deadline on November 17, 2023. More info <a href='https://cvpr.thecvf.com/Conferences/2024'>here</a>.
+
 
 - title: ICRA
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -252,7 +252,7 @@
   full_name: Conference on Health, Inference, and Learning
   link: https://www.chilconference.org/index.html
   deadline: '2024-02-16 23:59:59'
-  timezone: UTC-14
+  timezone: UTC-12
   place: New York, New York
   date: June, 27-28, 2024
   start: 2024-06-27

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: ACL
+  year: 2024
+  id: acl24
+  link: https://2024.aclweb.org/
+  deadline: '2024-02-15 23:59:00'
+  timezone: UTC-12
+  place: Bangkok, Thailand
+  date: August 11-16, 2024
+  start: 2024-08-11
+  end: 2024-08-16
+  hindex: 192
+  sub: NLP
+  note: All submissions should be done through ARR. More info <a href="https://www.aclweb.org/portal/sites/default/files/Submission%20Dates%20and%20Process%20for%20EACL_NAACL%20and%20ACL%202024-2.pdf">here</a>.
+
 - title: IROS
   year: 2024
   id: iros24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,16 @@
 ---
+- title: 3DV
+  year: 2024
+  id: threedv24
+  link: https://3dvconf.github.io/2024/
+  deadline: '2023-08-07 23:59:59'
+  timezone: America/Los_Angeles
+  place: Davos, Switzerland
+  date: March 18-21, 2024
+  start: 2024-03-18
+  end: 2024-03-21
+  sub: CV
+
 - title: CVPR
   year: 2024
   id: cvpr24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2259,5 +2259,5 @@
   date: August, 07-09, 2024
   start: 2024-08-07
   end: 2024-08-09
-  sub: SP
+  sub: ML
   note: Check the conference website for paper review available and notification of acceptance date.

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,32 @@
 ---
+- title: CSCW
+  year: 2024
+  id: cscw24_january
+  link: https://cscw.acm.org/2024/
+  deadline: '2024-01-16 23:59:59'
+  timezone: UTC-12
+  place: San José, Costa Rica
+  date: November, 9-13, 2024
+  start: 2024-11-09
+  end: 2024-11-13
+  hindex: 31
+  sub: CSCW
+  note: This is the January cycle.
+
+- title: IUI
+  year: 2024
+  id: iui24
+  link: https://iui.acm.org/2024/
+  deadline: '2023-10-09 23:59:59'
+  timezone: UTC-12
+  place: Greenville, South Carolina, USA
+  date: March, 18-21, 2024
+  start: 2024-03-18
+  end: 2024-03-21
+  hindex: 47
+  sub: HCI
+  note: Mandatory abstract deadline on Oct 2, 2023. More info <a href='https://iui.acm.org/2024/call_for_papers.html'>here</a>.
+
 - title: AISTATS
   year: 2024
   id: aistats24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -6,9 +6,11 @@
   deadline: '2024-03-29 23:59:00'
   timezone: UTC-12
   place: Vienna, Austria
-  date: July, 21, 2024
+  date: July 21, 2024
+  start: 2024-07-21
+  end: 2024-07-21
   sub: ML
-  note: "The deadline for submissions to the proceedings and workshop tracks is 29 March. The deadline for submitting a recently published paper to AABI's fast track is 10 May."
+  note: "Co-located with ICML 2024. Submission deadlines are March 29 (proceedings and workshop track) and May 10 (fast track). More info <a href="http://approximateinference.org/call/index.html">here</a>"
 
 - title: CoRL
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -111,13 +111,13 @@
   id: colm24
   full_name: 1st Conference on Language Modeling
   link: https://colmweb.org/
-  deadline: '2024-03-15 23:59:59'
-  abstract_deadline: '2024-03-8 23:59:59'
+  deadline: '2024-03-29 23:59:59'
+  abstract_deadline: '2024-03-22 23:59:59'
   timezone: UTC-12
   place: TBD
   date: October, 2024
   sub: NLP
-  note: Mandatory abstract deadline on March 8, 2024. More info <a href='https://colmweb.org/cfp.html'>here</a>.
+  note: Mandatory abstract deadline on March 22, 2024. More info <a href='https://colmweb.org/cfp.html'>here</a>.
 
 - title: IJCAI-PRICAI
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -237,9 +237,11 @@
   deadline: '2024-03-29 23:59:59'
   abstract_deadline: '2024-03-22 23:59:59'
   timezone: UTC-12
-  place: TBD
-  date: October, 2024
-  sub: NLP
+  place: Philadelphia, USA
+  date: October 7-9, 2024
+  start: 2024-10-07
+  end: 2024-10-09
+  sub: NLP, ML
   note: Mandatory abstract deadline on March 22, 2024. More info <a href='https://colmweb.org/cfp.html'>here</a>.
 
 - title: IJCAI

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,18 @@
 ---
+- title: WACV
+  year: 2024
+  id: wacv24
+  full_name: IEEE/CVF Winter Conference on Applications of Computer Vision
+  link: https://wacv2024.thecvf.com
+  deadline: '2023-08-30 11:59:59'
+  timezone: America/Los_Angeles
+  place: Waikoloa, Hawaii, USA
+  date: January 3-7, 2024
+  start: 2024-01-03
+  end: 2024-01-07
+  hindex: 76
+  sub: CV
+  note: Paper Registration is on Aug. 23rd 2023
 
 - title: 3DV
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,21 @@
 ---
+- title: IJCAI-PRICAI
+  year: 2024
+  id: ijcai24
+  full_name: International Joint Conference on Artificial Intelligence and 
+  Pacific Rim International Conference on Artificial Intelligence
+  link: https://ijcai24.org/
+  deadline: '2024-01-17 23:59:59'
+  abstract_deadline: '2024-01-10 23:59:59'
+  timezone: UTC-12
+  place: Jeju, South Korea
+  date: August 03-09, 2024
+  start: 2024-08-03
+  end: 2024-08-09
+  hindex: 133
+  sub: ML
+  note: Mandatory abstract deadline on January 10, 2024 and optional supplementary material deadline on January 24, 2024. More info <a href='https://ijcai24.org/'>here</a>.
+
 - title: SaTML
   year: 2024
   id: satml24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,15 @@
+- title: CoRL
+  year: 2024
+  id: corl24
+  link: https://sites.google.com/robot-learning.org/corl2024/
+  deadline: '2023-06-06 23:59:00'
+  timezone: UTC-12
+  place: Munich, Germany
+  date: November 06-09, 2024
+  start: 2024-11-06
+  end: 2024-11-09
+  sub: RO
+
 - title: MM
   year: 2024
   id: mm24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -52,7 +52,7 @@
   place: TBD
   date: October, 2024
   sub: NLP
-  note: Mandatory abstract deadline on March 8, 2024. More info [here](https://colmweb.org/cfp.html)
+  note: Mandatory abstract deadline on March 8, 2024. More info <a href='https://colmweb.org/cfp.html'>here</a>.
 
 - title: IJCAI-PRICAI
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,5 +1,17 @@
 ---
 
+- title: EACL
+  year: 2024
+  id: eacl24
+  deadline: '2023-10-15 23:59:59'
+  timezone: UTC-12
+  place: Malta
+  date: March 17-22, 2024
+  start: 2024-03-17
+  end: 2024-03-22
+  note: Submission via ACL Rolling Review, commitment date 2023-12-20
+  sub: NLP
+
 - title: 3DV
   year: 2024
   id: threedv24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -6,11 +6,11 @@
   deadline: '2024-01-16 23:59:59'
   timezone: UTC-12
   place: San José, Costa Rica
-  date: November, 9-13, 2024
+  date: November 9-13, 2024
   start: 2024-11-09
   end: 2024-11-13
   hindex: 31
-  sub: CSCW
+  sub: HCI
   note: This is the January cycle.
 
 - title: IUI
@@ -20,7 +20,7 @@
   deadline: '2023-10-09 23:59:59'
   timezone: UTC-12
   place: Greenville, South Carolina, USA
-  date: March, 18-21, 2024
+  date: March 18-21, 2024
   start: 2024-03-18
   end: 2024-03-21
   hindex: 47

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -17,7 +17,8 @@
   id: neurips24
   full_name: Conference on Neural Information Processing Systems
   link: https://nips.cc/Conferences/2024
-  deadline: '2024-05-22 20:00:00'
+  deadline: '2024-05-22 23:59:59'
+  abstract_deadline: '2024-05-15 23:59:59'
   timezone: UTC
   place: Vancouver, Canada
   date: December 9 - December 15, 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -12,7 +12,7 @@
   end: 2024-01-07
   hindex: 76
   sub: CV
-  note: Paper Registration is on Aug. 23rd 2023
+  note: This is the Round 2 submission. Paper Registration is on August 23rd 2023. More info <a href='https://wacv2024.thecvf.com/submissions/'>here</a>.
 
 - title: EACL
   year: 2024
@@ -107,21 +107,6 @@
   end: 2024-05-10
   sub: ML
   note: Mandatory abstract deadline on Oct 02, 2023. More info <a href='https://www.aamas2024-conference.auckland.ac.nz/calls/call-for-papers/'>here</a>.
-
-- title: WACV
-  year: 2024
-  id: wacv24
-  full_name: IEEE/CVF Winter Conference on Applications of Computer Vision
-  link: https://wacv2024.thecvf.com
-  deadline: '2023-06-28 11:59:59'
-  timezone: America/Los_Angeles
-  place: Waikoloa, Hawaii, USA
-  date: January 3-7, 2024
-  start: 2024-01-03
-  end: 2024-01-07
-  hindex: 76
-  sub: CV
-  note: Paper Registration is on Jun. 21st 2023; Second round submission deadline on Aug. 30th 2023
 
 - title: AAAI
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -125,7 +125,7 @@
   deadline: '2023-05-23 23:59:00'
   timezone: UTC-12
   place: Bali, Indonesia
-  date: November 1-4, 2022
+  date: November 1-4, 2023
   start: 2023-11-01
   end: 2023-11-04
   hindex: 37

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: KR
+  year: 2024
+  id: kr24
+  link: https://kr.org/KR2024/
+  deadline: '2024-05-01 23:59:59'
+  abstract_deadline: '2024-04-24 23:59:59'
+  timezone: UTC-12
+  place: Hanoi, Vietnam
+  date: Nov 02-08, 2024
+  start: 2024-11-02
+  end: 2024-11-08
+  hindex: -1
+  sub: KR
+  note: Mandatory abstract deadline on April 24, 2024. More info <a href='https://kr.org/KR2024/'>here</a>.
+
 - title: AAAI 2024 Spring Symposium on Clinical Foundation Models
   year: 2024
   id: aaaisss24cfm  # title as lower case + last two digits of year

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -116,7 +116,7 @@
   year: 2024
   id: aistats24
   link: https://www.aistats.org/aistats2024/
-  deadline: '2023-10-13 23:59:59'
+  deadline: '2023-10-16 23:59:59'
   timezone: UTC-12
   place: Valencia, Spain
   date: May 02-04, 2024
@@ -317,7 +317,7 @@
   id: lreccoling24
   full_name: The 2024 Joint International Conference on Computational Linguistics, Language Resources and Evaluation
   link: https://lrec-coling-2024.org
-  deadline: '2023-10-13 23:59:59'
+  deadline: '2023-10-20 23:59:59'
   timezone: UTC-12
   place: Torino, Italy
   date: May 20 - May 25, 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -294,7 +294,7 @@
   end: 2024-06-21
   hindex: 389
   sub: CV
-  note: Mandatory paper registration deadline on November 03, 2023 and optional supplementary material deadline on November 17, 2023. More info <a href='https://cvpr.thecvf.com/Conferences/2024'>here</a>.
+  note: Mandatory paper registration deadline on November 03, 2023 and optional supplementary material deadline on November 26, 2023. More info <a href='https://cvpr.thecvf.com/Conferences/2024'>here</a>.
 
 
 - title: ICRA

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,16 @@
 ---
+- title: UAI
+  year: 2024
+  id: uai24
+  link: https://www.auai.org/uai2024/
+  deadline: '2024-02-09 23:59:59'
+  timezone: UTC-12
+  place: Barcelona, Spain
+  date: July 15-19, 2024
+  start: 2024-07-15
+  end: 2024-07-19
+  sub: ML
+
 - title: ECAI
   year: 2024
   id: ecai24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: AAMAS
+  year: 2025
+  id: aamas25
+  link: https://aamas2025.org/
+  deadline: '2024-10-16 23:59:59'
+  abstract_deadline: '2024-10-09 23:59:59'
+  timezone: UTC-12
+  place: Detroit, Michigan, USA
+  date: May 19 - May 23, 2025
+  start: 2025-05-19
+  end: 2025-05-23
+  sub: ['KR', 'ML', 'RO', 'AP']
+  note: Mandatory abstract deadline on Oct 09, 2024. More info <a href='https://aamas2025.org/'>here</a>.
+
+
 - title: COLING
   year: 2025
   id: coling25

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: BMVC
+  year: 2024
+  id: bmvc24
+  full_name: The British Machine Vision Conference
+  link: https://bmvc2024.org/
+  deadline: '2024-05-10 23:59:59'
+  abstract_deadline: '2024-04-26 23:59:59'
+  timezone: GMT
+  place: Glasgow, UK
+  date: November 25 - November 28, 2024
+  start: 2024-11-25
+  end: 2024-11-28
+  sub: ML
+  note: Mandatory abstract deadline on April 26, 2024
+
 - title: KIL
   year: 2024
   id: kil24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,18 +1,18 @@
 - title: NeurIPS [Dataset and Benchmarks Track]
   year: 2024
-  id: neurips24
+  id: neurips24DBT
   full_name: Conference on Neural Information Processing Systems - Dataset and Benchmarks Track
   hindex: 309
   link: https://nips.cc/Conferences/2024/CallForDatasetsBenchmarks
   deadline: '2024-06-05 19:59:59'
-  abstract_deadline: '2024-04-29 19:59:59'
+  abstract_deadline: '2024-05-29 19:59:59'
   timezone: UTC
   place: Vancouver, Canada
   date: December 9 - December 15, 2024
   start: 2024-12-09
   end: 2024-12-15
   sub: ['DM', 'ML', 'NLP', 'SP', 'CV']
-  note: Mandatory abstract deadline on May 29, 2024, and supplementary material deadline on JUn 12, 2024. More info <a href='https://nips.cc/Conferences/2024/CallForDatasetsBenchmarks'>here</a>.
+  note: Mandatory abstract deadline on May 29, 2024, and supplementary material deadline on June 12, 2024. More info <a href='https://nips.cc/Conferences/2024/CallForDatasetsBenchmarks'>here</a>.
 
 - title: ICRA
   year: 2025

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -180,7 +180,7 @@
   full_name: AAAI Conference on Artificial Intelligence
   link: https://aaai.org/conference/aaai/aaai-25/
   deadline: '2024-08-15 23:59:59'
-  abstract_deadline: '2023-08-08 23:59:59'
+  abstract_deadline: '2024-08-07 23:59:59'
   timezone: UTC-12
   place: Philadelphia, USA
   date: February 25 - March 04, 2025
@@ -188,7 +188,7 @@
   end: 2025-03-04
   hindex: 212
   sub: ['DM', 'KR', 'ML', 'RO', 'NLP', 'SP', 'CV', 'CG', 'HCI', 'AP']
-  note: Mandatory abstract deadline on Aug 08, 2024, and supplementary material deadline on Aug 18, 2024. More info <a href='https://aaai.org/conference/aaai/aaai-25/'>here</a>.
+  note: Mandatory abstract deadline on Aug 07, 2024, and supplementary material deadline on Aug 19, 2024. More info <a href='https://aaai.org/conference/aaai/aaai-25/'>here</a>.
 
 - title: BMVC
   year: 2024
@@ -896,7 +896,7 @@
   full_name: AAAI Conference on Artificial Intelligence
   link: https://aaai.org/aaai-conference/
   deadline: '2023-08-15 23:59:59'
-  abstract_deadline: '2023-08-07 23:59:59'
+  abstract_deadline: '2023-08-08 23:59:59'
   timezone: UTC-12
   place: Vancouver, Canada
   date: February 20 - February 28, 2024
@@ -904,7 +904,7 @@
   end: 2024-02-28
   hindex: 180
   sub: ML
-  note: Mandatory abstract deadline on Aug 07, 2023, and supplementary material deadline on Aug 19, 2023. More info <a href='https://aaai.org/aaai-conference/'>here</a>.
+  note: Mandatory abstract deadline on Aug 08, 2023, and supplementary material deadline on Aug 18, 2023. More info <a href='https://aaai.org/aaai-conference/'>here</a>.
 
 - title: ECIR
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -72,14 +72,17 @@
   year: 2024
   id: neurips24
   full_name: Conference on Neural Information Processing Systems
+  hindex: 309
   link: https://nips.cc/Conferences/2024
-  deadline: '2024-05-22 23:59:59'
-  abstract_deadline: '2024-05-15 23:59:59'
+  paperslink: https://proceedings.neurips.cc/
+  pwclink: https://paperswithcode.com/conference/neurips-2024-12
+  deadline: '2024-05-22 19:59:59'
+  abstract_deadline: '2024-05-15 19:59:59'
   timezone: UTC
   place: Vancouver, Canada
   date: December 9 - December 15, 2024
   start: 2024-12-09
-  end: 2023-12-15
+  end: 2024-12-15
   sub: ML
   note: Mandatory abstract deadline on May 15, 2024
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: ECIR
+  year: 2025
+  id: ecir24
+  full_name: European Conference on Information Retrieval
+  link: https://ecir2025.eu/
+  deadline: '2024-10-09 23:59:59'
+  abstract_deadline: '2024-10-02 23:59:59'
+  timezone: UTC-12
+  place: Lucca, Tuscany, Italy
+  date: April 6 - April 10, 2025
+  start: 2025-04-06
+  end: 2025-04-10
+  sub: DM
+  note: Abstract deadline on Oct 2, 2024. More info <a href='https://ecir2025.eu/'>here</a>.  
+  
 - title: WACV
   year: 2025
   id: wacv25

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: WACV
+  year: 2025
+  id: wacv25
+  full_name: IEEE/CVF Winter Conference on Applications of Computer Vision
+  link: https://wacv2025.thecvf.com/
+  deadline: '2024-09-09 23:59:59'
+  timezone: UTC-7
+  place: Tucson, Arizona
+  date: Feb 28 – Mar 4, 2025
+  start: 2025-2-28
+  end: 2025-3-4
+  hindex: 109
+  sub: ['ML', 'CV']
+  note: This is the second round of submissions. Summplementary material deadline on Sep 11, 2024. More info <a href='https://wacv2025.thecvf.com/'>here</a>.
+  
 - title: AAMAS
   year: 2025
   id: aamas25

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -24,7 +24,7 @@
   start: 2025-02-25
   end: 2025-03-04
   hindex: 212
-  sub: ML
+  sub: ['DM', 'KR', 'ML', 'RO', 'NLP', 'SP', 'CV', 'CG', 'HCI', 'AP']
   note: Mandatory abstract deadline on Aug 07, 2024, and supplementary material deadline on Aug 19, 2024. More info <a href='https://aaai.org/aaai-conference/save-the-date-aaai-25/'>here</a>.
 
 - title: BMVC

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,19 @@
+- title: CHI
+  year: 2025
+  id: chi25
+  full_name: The ACM Conference on Human Factors in Computing Systems
+  link: https://chi2025.acm.org/
+  deadline: '2024-09-12 23:59:59'
+  abstract_deadline: '2024-09-05 23:59:59'
+  timezone: UTC-12
+  place: Yokohama, Japan
+  date: April 26 - May 01, 2025
+  start: 2025-04-26
+  end: 2025-05-01
+  hindex: 122
+  sub: HCI
+  note: Mandatory abstract deadline on Sep 05, 2024. More info <a href='https://chi2025.acm.org/for-authors/papers/'>here</a>.
+
 - title: COLING
   year: 2025
   id: coling25

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,6 +1,6 @@
 - title: ECIR
   year: 2025
-  id: ecir24
+  id: ecir25
   full_name: European Conference on Information Retrieval
   link: https://ecir2025.eu/
   deadline: '2024-10-09 23:59:59'
@@ -15,7 +15,7 @@
   
 - title: WACV
   year: 2025
-  id: wacv25
+  id: wacv25_2
   full_name: IEEE/CVF Winter Conference on Applications of Computer Vision
   link: https://wacv2025.thecvf.com/
   deadline: '2024-09-09 23:59:59'

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,19 @@
+- title: AAAI
+  year: 2025
+  id: aaai25
+  full_name: AAAI Conference on Artificial Intelligence
+  link: https://aaai.org/aaai-conference/save-the-date-aaai-25/
+  deadline: '2024-08-15 23:59:59'
+  abstract_deadline: '2023-08-07 23:59:59'
+  timezone: UTC-12
+  place: Philadelphia, USA
+  date: February 25 - March 04, 2025
+  start: 2025-02-25
+  end: 2025-03-04
+  hindex: 212
+  sub: ML
+  note: Mandatory abstract deadline on Aug 07, 2024, and supplementary material deadline on Aug 19, 2024. More info <a href='https://aaai.org/aaai-conference/save-the-date-aaai-25/'>here</a>.
+
 - title: CoRL
   year: 2024
   id: corl24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,16 @@
+- title: ICRA
+  year: 2025
+  id: icra25
+  link: https://2025.ieee-icra.org
+  deadline: '2024-09-15 23:59:59'
+  timezone: America/Los_Angeles
+  place: Atlanta, USA
+  date: May 19 - May 23, 2025
+  start: 2025-05-19
+  end: 2025-05-23
+  hindex: 119
+  sub: RO
+
 - title: AAAI
   year: 2025
   id: aaai25
@@ -650,7 +663,7 @@
 - title: ICRA
   year: 2024
   id: icra24
-  link: http://ieee-icra.org/
+  link: http://2024.ieee-icra.org/
   deadline: '2023-09-15 23:59:59'
   timezone: America/Los_Angeles
   place: Yokohama, Japan

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -256,7 +256,7 @@
   sub: ML
   note: Mandatory abstract deadline on May 15, 2024
 
-  - title: ECML PKDD
+- title: ECML PKDD
   year: 2024
   id: ecmlpkdd2024
   link: https://2024.ecmlpkdd.org/

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -58,6 +58,18 @@
   sub: ML
   note: Mandatory abstract deadline on April 26, 2024
 
+- title: ICASSP
+  year: 2025
+  id: icassp25
+  link: https://2025.ieeeicassp.org/
+  deadline: '2024-09-09 23:59:59'
+  timezone: UTC-12
+  place: Hyderabad, India
+  date: April 6-11, 2025
+  start: 2025-04-6
+  end: 2025-04-11
+  sub: SP
+
 - title: KIL
   year: 2024
   id: kil24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,19 @@
+- title: NeurIPS [Dataset and Benchmarks Track]
+  year: 2024
+  id: neurips24
+  full_name: Conference on Neural Information Processing Systems - Dataset and Benchmarks Track
+  hindex: 309
+  link: https://nips.cc/Conferences/2024/CallForDatasetsBenchmarks
+  deadline: '2024-06-05 19:59:59'
+  abstract_deadline: '2024-04-29 19:59:59'
+  timezone: UTC
+  place: Vancouver, Canada
+  date: December 9 - December 15, 2024
+  start: 2024-12-09
+  end: 2024-12-15
+  sub: ['DM', 'ML', 'NLP', 'SP', 'CV']
+  note: Mandatory abstract deadline on May 29, 2024, and supplementary material deadline on JUn 12, 2024. More info <a href='https://nips.cc/Conferences/2024/CallForDatasetsBenchmarks'>here</a>.
+
 - title: ICRA
   year: 2025
   id: icra25

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -41,6 +41,19 @@
   hindex: 119
   sub: RO
 
+  - title: WACV
+  year: 2025
+  id: wacv25
+  full_name: IEEE/CVF Winter Conference on Applications of Computer Vision
+  link: https://wacv2025.thecvf.com/
+  deadline: '2024-07-14 23:59:59'
+  timezone: America/Los_Angeles
+  place: Tucson, Arizona
+  date: Feb 28 – Mar 4, 2025
+  start: 2025-2-28
+  end: 2025-3-4
+  sub: ['ML', 'CV']
+
 - title: AAAI
   year: 2025
   id: aaai25

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: LoG
+  year: 2024
+  id: log24
+  full_name: Learning on Graphs Conference
+  link: https://logconference.org
+  deadline: 2024-09-11 23:59
+  abstract_deadline: 2024-09-04 23:59
+  timezone: UTC-12
+  place: Virtual, free to attend
+  date: November 26 - November 29, 2024
+  start: 2024-11-26
+  end: 2024-11-29
+  sub: ['ML', 'DM', 'KR']
+  note: Abstract deadline on Sep 04, 2024. More info <a href='https://logconference.org'>here</a>. 
+
 - title: ECIR
   year: 2025
   id: ecir25

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,19 @@
+- title: ICLR
+  year: 2025
+  id: iclr25
+  link: https://iclr.cc/Conferences/2025/CallForPapers
+  deadline: '2024-10-01 23:59:59'
+  abstract_deadline: '2024-09-27 23:59:59'
+  timezone: UTC-12
+  place: Singapore
+  date: Apr 24-28, 2025
+  start: 2025-04-24
+  end: 2025-04-28
+  hindex: 304
+  sub: ['ML', 'AP', 'RO', 'CV', 'NLP', 'SP']
+  note: Mandatory abstract deadline on September 27, 2024. More info <a href='https://iclr.cc/Conferences/2025/CallForPapers'>here</a>.
+  
+
 - title: LoG
   year: 2024
   id: log24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: COLING
+  year: 2025
+  id: coling25
+  full_name: The 31st International Conference on Computational Linguistics
+  link: https://coling2025.org/
+  deadline: '2024-09-16 23:59:59'
+  timezone: UTC-12
+  place: Abu Dhabi, UAE
+  date: January 19-24, 2025
+  start: 2025-01-19
+  end: 2025-01-24
+  hindex: 73
+  sub: NLP
+  note: More info can be found <a href="https://coling2025.org/calls/main_conference_papers/#important-dates">here</a>.
+
 - title: WSDM
   year: 2025
   id: wsdm25

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -896,7 +896,7 @@
   full_name: AAAI Conference on Artificial Intelligence
   link: https://aaai.org/aaai-conference/
   deadline: '2023-08-15 23:59:59'
-  abstract_deadline: '2023-08-08 23:59:59'
+  abstract_deadline: '2023-08-07 23:59:59'
   timezone: UTC-12
   place: Vancouver, Canada
   date: February 20 - February 28, 2024
@@ -904,7 +904,7 @@
   end: 2024-02-28
   hindex: 180
   sub: ML
-  note: Mandatory abstract deadline on Aug 08, 2023, and supplementary material deadline on Aug 18, 2023. More info <a href='https://aaai.org/aaai-conference/'>here</a>.
+  note: Mandatory abstract deadline on Aug 07, 2023, and supplementary material deadline on Aug 19, 2023. More info <a href='https://aaai.org/aaai-conference/'>here</a>.
 
 - title: ECIR
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -162,9 +162,9 @@
   year: 2025
   id: aaai25
   full_name: AAAI Conference on Artificial Intelligence
-  link: https://aaai.org/aaai-conference/save-the-date-aaai-25/
+  link: https://aaai.org/conference/aaai/aaai-25/
   deadline: '2024-08-15 23:59:59'
-  abstract_deadline: '2023-08-07 23:59:59'
+  abstract_deadline: '2023-08-08 23:59:59'
   timezone: UTC-12
   place: Philadelphia, USA
   date: February 25 - March 04, 2025
@@ -172,7 +172,7 @@
   end: 2025-03-04
   hindex: 212
   sub: ['DM', 'KR', 'ML', 'RO', 'NLP', 'SP', 'CV', 'CG', 'HCI', 'AP']
-  note: Mandatory abstract deadline on Aug 07, 2024, and supplementary material deadline on Aug 19, 2024. More info <a href='https://aaai.org/aaai-conference/save-the-date-aaai-25/'>here</a>.
+  note: Mandatory abstract deadline on Aug 08, 2024, and supplementary material deadline on Aug 18, 2024. More info <a href='https://aaai.org/conference/aaai/aaai-25/'>here</a>.
 
 - title: BMVC
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -83,6 +83,18 @@
   sub: ['DM', 'KR']
   note: Mandatory abstract deadline on May 13, 2024. More info <a href='https://cikm2024.org/call-for-papers/'>here</a>.
 
+- title: SIGGRAPH Asia
+  year: 2024
+  id: siggraphasia24  # title as lower case + last two digits of year
+  full_name: SIGGRAPH ASIA 2024  # full conference name
+  link: https://asia.siggraph.org/2024/
+  deadline: 2023-05-19 23:59
+  timezone: UTC-12
+  place: Tokyo, Japan
+  date: December, 12-15, 2023
+  sub: CG
+  note:
+
 - title: NeurIPS
   year: 2024
   id: neurips24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: Iberamia
+  year: 2024
+  id: iberamia24
+  full_name: 18th Ibero-American Conference on Artificial Intelligence
+  hindex: 14
+  link: https://www.iberamia.org/iberamia/iberamia2024/
+  deadline: '2024-06-09 23:59:59'
+  timezone: UTC-12
+  place: Montevideo, Uruguay
+  date: November 13-15, 2024
+  start: 2024-11-13
+  end: 2024-11-15
+  sub: ['ML', 'NLP', 'CV']
+
 - title: NeurIPS [Dataset and Benchmarks Track]
   year: 2024
   id: neurips24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -88,10 +88,10 @@
   id: siggraphasia24  # title as lower case + last two digits of year
   full_name: SIGGRAPH ASIA 2024  # full conference name
   link: https://asia.siggraph.org/2024/
-  deadline: 2023-05-19 23:59
+  deadline: 2024-05-19 23:59
   timezone: UTC-12
   place: Tokyo, Japan
-  date: December, 12-15, 2023
+  date: December, 3-6, 2024
   sub: CG
   note:
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,8 +1,8 @@
 - title: WSDM
-  full_name: ACM International Conference on Web Search and Data Mining
-  note: Abstract deadline on August 7, 2024
   year: 2025
   id: wsdm25
+  full_name: ACM International Conference on Web Search and Data Mining
+  note: Abstract deadline on August 7, 2024
   link: https://www.wsdm-conference.org/2025/
   deadline: '2024-08-14 23:59:00'
   timezone: UTC-12
@@ -55,7 +55,7 @@
   hindex: 119
   sub: RO
 
-  - title: WACV
+- title: WACV
   year: 2025
   id: wacv25
   full_name: IEEE/CVF Winter Conference on Applications of Computer Vision

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: NAACL
+  year: 2025
+  id: naacl25
+  link: https://2025.naacl.org
+  deadline: '2024-10-15 23:59:59'
+  timezone: UTC-12
+  place: Albuquerque, New Mexico, USA
+  date: April 29- May 4, 2024
+  start: 2025-04-29
+  end: 2025-05-04
+  hindex: 132
+  sub: NLP
+  note: All submissions must be done through ARR. More info <a href='https://2025.naacl.org/calls/papers/'>here</a>.
+
 - title: ICLR
   year: 2025
   id: iclr25

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: WSDM
+  full_name: ACM International Conference on Web Search and Data Mining
+  note: Abstract deadline on August 7, 2024
+  year: 2025
+  id: wsdm25
+  link: https://www.wsdm-conference.org/2025/
+  deadline: '2024-08-14 23:59:00'
+  timezone: UTC-12
+  place: Hannover, Germany
+  date: March 10-14, 2025
+  start: 2025-03-10
+  end: 2025-03-14
+  sub: DM
+
 - title: Iberamia
   year: 2024
   id: iberamia24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -256,6 +256,20 @@
   sub: ML
   note: Mandatory abstract deadline on May 15, 2024
 
+  - title: ECML PKDD
+  year: 2024
+  id: ecmlpkdd2024
+  link: https://2024.ecmlpkdd.org/
+  deadline: '2024-07-22 23:59:59'
+  timezone: UTC-12
+  place: Vilnius (Lithuania)
+  date: September 9-13, 2024
+  start: 2024-09-09
+  end: 2024-09-13
+  paperslink: https://ecmlpkdd.org/2024/program-at-a-glance/
+  hindex: 45
+  sub: ML
+
 - title: AABI
   year: 2024
   id: aabi24

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -142,7 +142,6 @@
   end: 2024-07-21
   sub: ML
   note: Co-located with ICML 2024. Submission deadlines are March 29 (proceedings and workshop track) and May 10 (fast track). More info <a href="http://approximateinference.org/call/index.html">here</a>
->>>>>>> d982ce4ec57c6e4d7f0351d45ef1b953b8427697
 
 - title: CoRL
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2548,3 +2548,17 @@
   sub: ML
   note: Check the conference website for tutorials, contributions to the journal track and workshop deadlines
 
+
+- title: 3DV
+  year: 2025
+  id: 3dv25
+  full_name: International Conference on 3D Vision
+  link: https://3dvconf.github.io/2025/
+  deadline: '2024-08-12 23:59:59'
+  timezone: UTC-0
+  place: Singapore
+  date: March, 25-28, 2025
+  start: '2025-03-25'
+  end: '2025-03-28'
+  sub: CV
+  hindex: 47

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: SaTML
+  year: 2027
+  id: satml27
+  full_name: IEEE Conference on Secure and Trustworthy Machine Learning
+  link: https://satml.org/
+  deadline: '2026-09-29 23:59:59'
+  timezone: UTC-12
+  place: Reykjavik, Iceland
+  date: Early May, 2027
+  start: ''
+  end: ''
+  sub: ML
+  note: Exact conference dates are TBA. More info <a href='https://satml.org/call-for-papers/'>here</a>.
+
 - title: AISTATS
   year: 2025
   id: aistats25

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: FAccT
+  year: 2027
+  id: facct27
+  full_name: ACM Conference on Fairness, Accountability, and Transparency
+  link: https://facctconference.org/2027/cfp.html
+  deadline: '2026-11-03 23:59:59'
+  abstract_deadline: '2026-10-27 23:59:59'
+  timezone: UTC-12
+  place: TBA
+  date: June 21-24, 2027
+  start: 2027-06-21
+  end: 2027-06-24
+  sub: ML
+  note: Mandatory abstract deadline on October 27, 2026. More info <a href='https://facctconference.org/2027/cfp.html'>here</a>.
+
 - title: SaTML
   year: 2027
   id: satml27

--- a/_includes/calendar.js
+++ b/_includes/calendar.js
@@ -81,6 +81,30 @@
         },
         dataSource: conf_list_all
       }
+function parse_local_date(date_string) {
+  var parts = date_string.split("-");
+  if (parts.length !== 3) {
+    return new Date(date_string);
+  }
+
+  return new Date(
+    parseInt(parts[0], 10),
+    parseInt(parts[1], 10) - 1,
+    parseInt(parts[2], 10)
+  );
+}
+
+function parse_deadline(date_string, timezone) {
+  var fixed_offset = timezone.match(/^(?:UTC|GMT)([+-]\d{1,2})$/);
+  if (fixed_offset) {
+    return moment.utc(date_string)
+      .subtract(parseInt(fixed_offset[1], 10), "hours")
+      .toDate();
+  }
+
+  return moment.tz(date_string, timezone).toDate();
+}
+
 function load_conference_list() {
   // Gather data
   var conf_list_all = [];
@@ -95,8 +119,8 @@ function load_conference_list() {
       date: "{{conf.date}}",
       hindex: "{{conf.hindex}}",
       subject: "{{conf.sub}}",
-      startDate: Date.parse("{{conf.deadline}}"),
-      endDate: Date.parse("{{conf.deadline}}"),
+      startDate: parse_deadline("{{conf.deadline}}", "{{conf.timezone}}"),
+      endDate: parse_deadline("{{conf.deadline}}", "{{conf.timezone}}"),
     });
 
     // add Conferences in chosen color
@@ -117,8 +141,8 @@ function load_conference_list() {
         date: "{{conf.date}}",
         hindex: "{{conf.hindex}}",
         subject: "{{conf.sub}}",
-        startDate: Date.parse("{{conf.start}}"),
-        endDate: Date.parse("{{conf.end}}"),
+        startDate: parse_local_date("{{conf.start}}"),
+        endDate: parse_local_date("{{conf.end}}"),
       });
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
Fixes two site issues:

- Treat missing and empty abstract deadlines the same, so blank dates are not shown.
- Build filter URLs from the current path, so Past Deadlines filters stay on `/past/`.

Checked the Liquid conditions and JavaScript syntax. I also tested filter URLs in a browser.