### PR TITLE
Fix deadline and filter handling

### DIFF
--- a/_includes/calendar.js
+++ b/_includes/calendar.js
@@ -99,7 +99,7 @@ function load_conference_list() {
       endDate: Date.parse("{{conf.deadline}}"),
     });
 
-    {% if conf.abstract_deadline != "" %}
+    {% if conf.abstract_deadline and conf.abstract_deadline != "" %}
     conf_list_all.push({
       id: "{{conf.id}}-abstract-deadline",
       abbreviation: "{{conf.id}}",

--- a/_includes/utils.js
+++ b/_includes/utils.js
@@ -15,7 +15,7 @@ function addUtcTimeZones() {
 }
 
 function update_filtering(data) {
-  var page_url = "{{site.baseurl}}";
+  var page_url = window.location.pathname;
   store.set("{{site.domain}}-subs", data.subs);
 
   $(".ConfItem").hide();
@@ -27,10 +27,10 @@ function update_filtering(data) {
     }
   }
 
-  if (subs.length == 0) {
+  if (data.subs.length == 0) {
     window.history.pushState("", "", page_url);
   } else {
-    window.history.pushState("", "", page_url + "/?sub=" + data.subs.join());
+    window.history.pushState("", "", page_url + "?sub=" + data.subs.join());
   }
 }
 

--- a/_pages/conference.html
+++ b/_pages/conference.html
@@ -193,7 +193,7 @@ permalink: /conference/
       }
 
       // abstract deadline
-      {% if conf.abstract_deadline %}
+      {% if conf.abstract_deadline and conf.abstract_deadline != "" %}
       console.log("Abstract deadline: {{conf.abstract_deadline}}");
       try {
         var abstractDeadline = moment.tz("{{conf.abstract_deadline}}", timezone);

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
                 {% endif %}
               </div>
               <div class="col-12 col-sm-6">
-                {% if conf.abstract_deadline %}
+                {% if conf.abstract_deadline and conf.abstract_deadline != "" %}
                 <div class="deadline">
                   <div>
                     <b>Abstract deadline:</b>
@@ -237,7 +237,7 @@
         var timezone = {% if conf.timezone %}"{{conf.timezone}}" {% else %} "America/New_York" {% endif %};
       var confDate = moment.tz("{{conf.deadline}}", timezone);
       var abstractDeadline = null;
-      {% if conf.abstract_deadline %}
+      {% if conf.abstract_deadline and conf.abstract_deadline != "" %}
       abstractDeadline = moment.tz("{{conf.abstract_deadline}}", timezone);
       {% endif %}
 

--- a/past.html
+++ b/past.html
@@ -189,7 +189,7 @@ permalink: /past/
                 {% endif %}
               </div>
               <div class="col-12 col-sm-6">
-                {% if conf.abstract_deadline %}
+                {% if conf.abstract_deadline and conf.abstract_deadline != "" %}
                 <div class="deadline">
                   <div>
                     <b>Abstract deadline:</b>
@@ -260,7 +260,7 @@ permalink: /past/
         var timezone = {% if conf.timezone %}"{{conf.timezone}}" {% else %} "America/New_York" {% endif %};
         var confDate = moment.tz("{{conf.deadline}}", timezone);
         var abstractDeadline = null;
-        {% if conf.abstract_deadline %}
+        {% if conf.abstract_deadline and conf.abstract_deadline != "" %}
         abstractDeadline = moment.tz("{{conf.abstract_deadline}}", timezone);
         {% endif %}
 


### PR DESCRIPTION
Fixes two site issues:

- Treat missing and empty abstract deadlines the same, so blank dates are not shown.
- Build filter URLs from the current path, so Past Deadlines filters stay on `/past/`.

Checked the Liquid conditions and JavaScript syntax. I also tested filter URLs in a browser.
